### PR TITLE
fix(shims): typed error mapping and faithful system/developer roles

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -166,7 +166,7 @@ translators emit OpenAI/Anthropic/ACP SSE.
 | `{"type": "thinking"}` | `content: str` | `agent_thought_chunk` |
 | `{"type": "tool_call"}` | `id, name, arguments: dict` | `tool_call` |
 | `{"type": "done"}` | `finish_reason: str, usage: dict` | prompt result `stopReason` |
-| `{"type": "error"}` | `message: str` | JSON-RPC error / subprocess exit |
+| `{"type": "error"}` | `message: str`, optional `code: int`, `data: Any` | JSON-RPC error / subprocess exit |
 
 - Events are **dicts** — access with `event.get("type")`, never attribute access.
   This is what the tests assert and the routes consume.
@@ -174,6 +174,44 @@ translators emit OpenAI/Anthropic/ACP SSE.
   `tool_use → tool_calls`); the Anthropic route maps `stop → end_turn` back.
 - `thinking` is **not** surfaced on the OpenAI/Anthropic content streams; it is
   emitted as an event for native-ACP consumers.
+- `error` events carry the JSON-RPC `code`/`data` when available so
+  `kiro.error_mapping` can classify them; non-streaming completions surface the
+  same failure as an `ACPError(code, message, data)`.
+
+## Error Mapping (`kiro/error_mapping.py`)
+
+A single classifier maps ACP/upstream failures to an HTTP status code and the
+**native** OpenAI/Anthropic error envelope, used by **both** shims in **both**
+modes — never a bare `502 {"detail": ...}`.
+
+| Condition (matched in message/data) | Status | OpenAI `type` | Anthropic `type` |
+|---|---|---|---|
+| rate limit / throttle / quota / `429` | `429` | `rate_limit_error` | `rate_limit_error` |
+| overloaded / unavailable / capacity | `503` | `server_error` | `overloaded_error` |
+| timeout / deadline | `504` | `server_error` | `api_error` |
+| default | `502` | `server_error` | `api_error` |
+
+- `classify_exception(exc)` for non-streaming (reads `ACPError.code/.data`);
+  `classify_event(event)` for streaming error events. Both delegate to
+  `classify_error(message, code, data)` — classification is message-based.
+- Non-streaming routes return a native error `JSONResponse` (with a
+  `Retry-After` header when the message carries a retry hint); streaming routes
+  put the mapped `type` in the terminal error event (the stream is already
+  `200`). When adding error handling, keep all four paths consistent.
+
+## System & developer roles
+
+`PromptMessage.role` is `user | assistant | system | developer`. Instruction
+provenance is preserved instead of being flattened to anonymous user text:
+
+- OpenAI `system`/`developer` keep their roles; `tool`/other → `user` (tool
+  results keep a `[tool_result id=…]` marker). Responses `instructions` → `system`.
+- Anthropic `system` (string or block list) → a single `system` role (no ad-hoc
+  `[system]` user prefix).
+- `ACPClient._build_prompt_blocks` renders each message with a `System:` /
+  `Developer:` / `User:` / `Assistant:` label, preserving order and keeping
+  multiple system messages distinct. ACP exposes no system channel, so this
+  labelled single-block serialisation is the faithful representation.
 
 ## API Endpoints
 

--- a/README.md
+++ b/README.md
@@ -345,6 +345,59 @@ http://localhost:8000/acp/chat/stream  # SSE streaming
 
 ---
 
+## Error handling
+
+ACP/upstream failures are classified into the correct HTTP status code and
+returned in each API's **native error shape** (instead of a generic `502` with
+a bare `{"detail": ...}` body), so harness retry/back-off logic behaves
+correctly. The same classification applies to **both shims** and **both**
+streaming and non-streaming paths.
+
+| Upstream condition | HTTP status | OpenAI error `type` | Anthropic error `type` |
+|---|---|---|---|
+| Rate limit / throttle / quota / `429` | `429` | `rate_limit_error` | `rate_limit_error` |
+| Overloaded / unavailable / capacity | `503` | `server_error` | `overloaded_error` |
+| Timeout / deadline exceeded | `504` | `server_error` | `api_error` |
+| Any other failure (default) | `502` | `server_error` | `api_error` |
+
+- **Non-streaming.** The response status code is the mapped code and the body
+  is the native envelope — OpenAI `{"error": {"message", "type", "code",
+  "param"}}`; Anthropic `{"type": "error", "error": {"type", "message"}}`. When
+  the upstream message carries a retry hint (e.g. "retry after 30"), a
+  `Retry-After` header is added (most relevant for `429`).
+- **Streaming.** The SSE stream has already begun (HTTP `200`), so the mapped
+  error `type` is carried in the terminal error event: an OpenAI error chunk
+  (followed by `[DONE]`), a Responses `response.failed` event, or an Anthropic
+  `error` event.
+
+Classification is message-based (kiro-cli surfaces upstream conditions as
+text), so it works identically whether the failure arrives as a JSON-RPC error
+on a non-streaming completion or as a streaming error event.
+
+---
+
+## System & developer roles
+
+Instruction provenance is preserved rather than flattened into anonymous user
+text. ACP has no dedicated system channel, so a fresh-session prompt is
+serialised into a single text block — but each message keeps its role label
+(`System:` / `Developer:` / `User:` / `Assistant:`) and its order, and multiple
+system messages are kept distinct rather than merged.
+
+| Client input | Carried as | Rendered prompt label |
+|---|---|---|
+| OpenAI `system` message | `system` role | `System:` |
+| OpenAI `developer` message | `developer` role | `Developer:` |
+| OpenAI `tool` message | `user` role (with `[tool_result id=…]` marker) | `User:` |
+| OpenAI Responses `instructions` | `system` role | `System:` |
+| Anthropic `system` field (string or block list) | `system` role | `System:` |
+
+> kiro-cli treats the whole serialised prompt as one turn; these labels make
+> the system/developer instructions legible to the agent without inventing a
+> system channel the protocol does not expose.
+
+---
+
 ## Generation parameters
 
 Sampling parameters are accepted on both shims, validated, and **forwarded** to

--- a/kiro/acp_client.py
+++ b/kiro/acp_client.py
@@ -369,7 +369,11 @@ class ACPClient:
                 finish_reason = event.get("finish_reason", "stop")
                 usage = event.get("usage", {}) or {}
             elif etype == "error":
-                raise ACPError(-32000, event.get("message", "ACP prompt failed"))
+                raise ACPError(
+                    event.get("code", -32000),
+                    event.get("message", "ACP prompt failed"),
+                    event.get("data"),
+                )
 
         return {
             "content": "".join(content_parts),
@@ -539,7 +543,12 @@ class ACPClient:
         message is sent verbatim; multi-turn histories are rendered with
         ``Role:`` labels so the agent retains context.
         """
-        label = {"user": "User", "assistant": "Assistant", "system": "System"}
+        label = {
+            "user": "User",
+            "assistant": "Assistant",
+            "system": "System",
+            "developer": "Developer",
+        }
         parts: list[tuple[str, str]] = []
         for m in messages:
             role = getattr(m, "role", None) if not isinstance(m, dict) else m.get("role")
@@ -658,7 +667,7 @@ class ACPClient:
                 fut.set_exception(ACPError(-32000, message))
         self._pending.clear()
         for queue in list(self._event_queues.values()):
-            queue.put_nowait({"type": "error", "message": message})
+            queue.put_nowait({"type": "error", "message": message, "code": -32000})
 
     def _dispatch(self, line: str) -> None:
         """Route a single JSON-RPC line to the right handler."""
@@ -702,6 +711,8 @@ class ACPClient:
             queue.put_nowait({
                 "type": "error",
                 "message": err.get("message", "ACP prompt error"),
+                "code": err.get("code"),
+                "data": err.get("data"),
             })
             return
         result = msg.get("result") or {}

--- a/kiro/acp_models.py
+++ b/kiro/acp_models.py
@@ -68,7 +68,7 @@ ACPContentBlock = ContentBlock
 # ---------------------------------------------------------------------------
 
 class PromptMessage(BaseModel):
-    role: Literal["user", "assistant", "system"]
+    role: Literal["user", "assistant", "system", "developer"]
     content: Union[str, List[Dict[str, Any]]]
 
 

--- a/kiro/error_mapping.py
+++ b/kiro/error_mapping.py
@@ -1,0 +1,237 @@
+# -*- coding: utf-8 -*-
+"""
+Error mapping — classify ACP/upstream failures into HTTP status codes and the
+OpenAI/Anthropic *native* error shapes.
+
+Background
+----------
+The shims historically mapped every failure to a generic ``502`` with a bare
+``{"detail": ...}`` body. That breaks harness retry/back-off logic: a transient
+rate-limit (which a well-behaved client should retry with back-off) was
+indistinguishable from a permanent gateway error, and the body did not match
+the OpenAI/Anthropic error envelope clients parse.
+
+This module centralises a single classification used by **both** shims in
+**both** streaming and non-streaming paths, so error fidelity is consistent.
+
+Classification
+--------------
+Failures reach the gateway as :class:`kiro.acp_client.ACPError` (carrying a
+JSON-RPC ``code``/``message``/``data``) for non-streaming completions, or as
+normalised ``{"type": "error", "message", "code", "data"}`` events for
+streaming. Both carry a human-readable message from kiro-cli/upstream, so the
+classification is primarily message/data based with the JSON-RPC code as a
+secondary signal.
+
+| Condition (matched in message/data) | HTTP status | OpenAI ``type`` | Anthropic ``type`` |
+|--------------------------------------|-------------|-----------------|--------------------|
+| rate limit / throttle / quota / 429  | 429         | rate_limit_error| rate_limit_error   |
+| overloaded / unavailable / capacity  | 503         | server_error    | overloaded_error   |
+| timeout / deadline                   | 504         | server_error    | api_error          |
+| (default)                            | 502         | server_error    | api_error          |
+"""
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from typing import Any, Optional
+
+
+# ---------------------------------------------------------------------------
+# Signal patterns
+# ---------------------------------------------------------------------------
+
+_RATE_LIMIT_RE = re.compile(
+    r"(rate[\s_-]?limit(?:ed|ing)?|too\s+many\s+requests|throttl(?:e|ed|ing)|"
+    r"quota\s+exceeded|insufficient_quota|\b429\b)",
+    re.IGNORECASE,
+)
+
+_OVERLOADED_RE = re.compile(
+    r"(overloaded|service\s+unavailable|temporarily\s+unavailable|"
+    r"at\s+capacity|over\s+capacity|try\s+again\s+later|\b503\b|\b529\b)",
+    re.IGNORECASE,
+)
+
+_TIMEOUT_RE = re.compile(
+    r"(timed?\s*out|time[\s_-]?out|deadline\s+exceeded|\b504\b|\b408\b)",
+    re.IGNORECASE,
+)
+
+# Extract a Retry-After hint (seconds) from common phrasings, e.g.
+# "retry after 30", "retry-after: 30", "try again in 30 seconds".
+_RETRY_AFTER_RE = re.compile(
+    r"(?:retry[\s_-]?after[:\s]+|try\s+again\s+in\s+)(\d+)",
+    re.IGNORECASE,
+)
+
+
+@dataclass(frozen=True)
+class MappedError:
+    """A classified error ready to render in either API's native shape.
+
+    Attributes:
+        status_code: The HTTP status code to return (non-streaming) or that the
+            error semantically represents (streaming).
+        message: The human-readable error message surfaced to the client.
+        openai_type: The OpenAI error ``type`` string.
+        anthropic_type: The Anthropic error ``type`` string.
+        retry_after: Seconds to wait before retrying, when derivable; otherwise
+            ``None``. Surfaced as the ``Retry-After`` header on non-streaming
+            responses (most relevant for ``429``).
+    """
+
+    status_code: int
+    message: str
+    openai_type: str
+    anthropic_type: str
+    retry_after: Optional[int] = None
+
+    # -- Native error envelopes --------------------------------------------
+
+    def to_openai_error(self) -> dict[str, Any]:
+        """Render the OpenAI error envelope: ``{"error": {...}}``."""
+        return {
+            "error": {
+                "message": self.message,
+                "type": self.openai_type,
+                "code": None,
+                "param": None,
+            }
+        }
+
+    def to_anthropic_error(self) -> dict[str, Any]:
+        """Render the Anthropic error envelope: ``{"type": "error", "error": {...}}``."""
+        return {
+            "type": "error",
+            "error": {
+                "type": self.anthropic_type,
+                "message": self.message,
+            },
+        }
+
+    def headers(self) -> dict[str, str]:
+        """Return HTTP headers for the error (e.g. ``Retry-After`` on 429/503)."""
+        if self.retry_after is not None:
+            return {"Retry-After": str(self.retry_after)}
+        return {}
+
+
+# ---------------------------------------------------------------------------
+# Classification
+# ---------------------------------------------------------------------------
+
+def classify_error(
+    message: str,
+    code: Optional[int] = None,
+    data: Any = None,
+) -> MappedError:
+    """Classify a raw ACP/upstream error into a :class:`MappedError`.
+
+    The classification inspects the error message and any structured ``data``
+    for rate-limit / overloaded / timeout signals. The JSON-RPC ``code`` is
+    accepted for context/forward-compatibility but the message is the primary
+    signal (kiro-cli surfaces upstream conditions as text).
+
+    Args:
+        message: The error message from kiro-cli/upstream.
+        code: Optional JSON-RPC error code accompanying the failure.
+        data: Optional structured error data (dict/str) to also scan.
+
+    Returns:
+        A :class:`MappedError` with the resolved status code, native error
+        ``type`` strings and an optional ``Retry-After`` hint.
+    """
+    text = message or ""
+    if data is not None:
+        text = f"{text} {data!r}"
+
+    retry_after = _extract_retry_after(text)
+
+    if _RATE_LIMIT_RE.search(text):
+        return MappedError(
+            status_code=429,
+            message=message or "Rate limit exceeded",
+            openai_type="rate_limit_error",
+            anthropic_type="rate_limit_error",
+            retry_after=retry_after,
+        )
+
+    if _OVERLOADED_RE.search(text):
+        return MappedError(
+            status_code=503,
+            message=message or "Service temporarily overloaded",
+            openai_type="server_error",
+            anthropic_type="overloaded_error",
+            retry_after=retry_after,
+        )
+
+    if _TIMEOUT_RE.search(text):
+        return MappedError(
+            status_code=504,
+            message=message or "Upstream request timed out",
+            openai_type="server_error",
+            anthropic_type="api_error",
+            retry_after=retry_after,
+        )
+
+    return MappedError(
+        status_code=502,
+        message=message or "Upstream error",
+        openai_type="server_error",
+        anthropic_type="api_error",
+        retry_after=retry_after,
+    )
+
+
+def classify_exception(exc: BaseException) -> MappedError:
+    """Classify an exception (typically :class:`ACPError`) into a MappedError.
+
+    Reads ``code``/``data`` attributes when present (as on
+    :class:`kiro.acp_client.ACPError`) and falls back to ``str(exc)`` for the
+    message.
+
+    Args:
+        exc: The raised exception to classify.
+
+    Returns:
+        The corresponding :class:`MappedError`.
+    """
+    code = getattr(exc, "code", None)
+    data = getattr(exc, "data", None)
+    return classify_error(str(exc), code=code, data=data)
+
+
+def classify_event(event: dict[str, Any]) -> MappedError:
+    """Classify a normalised streaming ``error`` event into a MappedError.
+
+    Args:
+        event: A dict with at least ``message`` and optionally ``code``/``data``
+            (see :mod:`kiro.acp_client`).
+
+    Returns:
+        The corresponding :class:`MappedError`.
+    """
+    return classify_error(
+        event.get("message") or event.get("error") or "Unknown error",
+        code=event.get("code"),
+        data=event.get("data"),
+    )
+
+
+def _extract_retry_after(text: str) -> Optional[int]:
+    """Pull a Retry-After value (seconds) out of an error string, if present.
+
+    Args:
+        text: The combined error message/data text to scan.
+
+    Returns:
+        The parsed integer seconds, or ``None`` when no hint is found.
+    """
+    match = _RETRY_AFTER_RE.search(text)
+    if not match:
+        return None
+    try:
+        return int(match.group(1))
+    except (TypeError, ValueError):  # pragma: no cover - regex guarantees digits
+        return None

--- a/kiro/routes_anthropic_shim.py
+++ b/kiro/routes_anthropic_shim.py
@@ -36,14 +36,15 @@ import time
 import uuid
 from typing import Any, AsyncIterator, Optional
 
-from fastapi import APIRouter, Depends, HTTPException, Header, Request
-from fastapi.responses import StreamingResponse
+from fastapi import APIRouter, Depends, Header, Request
+from fastapi.responses import JSONResponse, StreamingResponse
 from loguru import logger
 from pydantic import BaseModel, Field
 
 from kiro.acp_models import PromptMessage, ToolResult, FilesystemRoot, TerminalCapability
 from kiro.auth import verify_anthropic_key
 from kiro.config import DEFAULT_KIRO_MODELS
+from kiro.error_mapping import MappedError, classify_event, classify_exception
 from kiro.shim_service import ShimService
 from kiro.tokenizer import estimate_request_tokens
 
@@ -134,7 +135,11 @@ def _anthropic_messages_to_acp(
     result = []
     system_text = _system_to_text(system)
     if system_text:
-        result.append(PromptMessage(role="user", content=f"[system]\n{system_text}"))
+        # Preserve the system prompt as a distinct system role. ACP has no
+        # dedicated system channel, so the prompt serialiser renders it with a
+        # ``System:`` label — faithful to its provenance, instead of the older
+        # ad-hoc ``[system]`` prefix on a user turn.
+        result.append(PromptMessage(role="system", content=system_text))
 
     for m in messages:
         role = "user" if m.role == "user" else "assistant"
@@ -184,6 +189,25 @@ def _anthropic_tools_to_acp(tools: list[AnthropicTool]) -> list[dict]:
 
 def _get_shim(request: Request) -> ShimService:
     return request.app.state.shim_service
+
+
+def _anthropic_error_response(mapped: MappedError) -> JSONResponse:
+    """Build a native Anthropic error ``JSONResponse`` from a classified error.
+
+    Args:
+        mapped: The classified error carrying the status code, message, native
+            ``type`` and optional ``Retry-After`` hint.
+
+    Returns:
+        A :class:`JSONResponse` with the Anthropic ``{"type": "error",
+        "error": {...}}`` body, the mapped HTTP status code, and a
+        ``Retry-After`` header when available.
+    """
+    return JSONResponse(
+        status_code=mapped.status_code,
+        content=mapped.to_anthropic_error(),
+        headers=mapped.headers(),
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -254,8 +278,11 @@ async def create_message(
             terminal=terminal,
         )
     except Exception as exc:
-        logger.error(f"Anthropic shim complete error: {exc}")
-        raise HTTPException(status_code=502, detail=str(exc))
+        mapped = classify_exception(exc)
+        logger.error(
+            f"Anthropic shim complete error (status={mapped.status_code}): {exc}"
+        )
+        return _anthropic_error_response(mapped)
 
     content_blocks: list[dict] = []
     if result["content"]:
@@ -444,21 +471,22 @@ async def _stream_response(
                 break
 
             elif etype == "error":
-                message = event.get("message") or event.get("error") or "Unknown ACP error"
+                mapped = classify_event(event)
                 yield sse("error", {
                     "type": "error",
                     "error": {
-                        "type": "api_error",
-                        "message": message,
+                        "type": mapped.anthropic_type,
+                        "message": mapped.message,
                     },
                 })
                 break
 
     except Exception as exc:
-        logger.error(f"Anthropic stream error: {exc}")
+        mapped = classify_exception(exc)
+        logger.error(f"Anthropic stream error (status={mapped.status_code}): {exc}")
         yield sse("error", {
             "type": "error",
-            "error": {"type": "gateway_error", "message": str(exc)},
+            "error": {"type": mapped.anthropic_type, "message": mapped.message},
         })
 
 

--- a/kiro/routes_openai_shim.py
+++ b/kiro/routes_openai_shim.py
@@ -28,13 +28,14 @@ import uuid
 from typing import Any, AsyncIterator, Optional
 
 from fastapi import APIRouter, Depends, HTTPException, Header, Request
-from fastapi.responses import StreamingResponse
+from fastapi.responses import JSONResponse, StreamingResponse
 from loguru import logger
 from pydantic import BaseModel, Field
 
 from kiro.acp_models import PromptMessage, ToolResult, FilesystemRoot, TerminalCapability
 from kiro.auth import verify_openai_key
 from kiro.config import DEFAULT_KIRO_MODELS
+from kiro.error_mapping import MappedError, classify_event, classify_exception
 from kiro.shim_service import ShimService
 
 router = APIRouter(prefix="/v1", tags=["OpenAI Shim"])
@@ -83,14 +84,36 @@ class OAIChatRequest(BaseModel):
 # ---------------------------------------------------------------------------
 
 def _oai_messages_to_acp(messages: list[OAIMessage]) -> list[PromptMessage]:
-    """Convert OpenAI message list to ACP PromptMessage list."""
+    """Convert an OpenAI message list to an ACP ``PromptMessage`` list.
+
+    Role handling preserves instruction provenance instead of silently
+    flattening it into anonymous user text:
+
+    * ``system`` and ``developer`` are kept as distinct roles. ACP has no
+      dedicated system channel, so the prompt serialiser
+      (:func:`ACPClient._build_prompt_blocks`) renders them with explicit
+      ``System:`` / ``Developer:`` labels, keeping each message separate and in
+      order rather than merging them.
+    * ``assistant`` is preserved.
+    * ``tool`` (and any other role) is rendered as ``user`` content; tool
+      results additionally carry a ``[tool_result id=...]`` marker for context.
+
+    Args:
+        messages: The OpenAI request messages.
+
+    Returns:
+        A list of :class:`PromptMessage` preserving role provenance.
+    """
     result = []
     for m in messages:
         role = m.role
-        if role == "system":
-            role = "user"  # ACP uses user role for system context
-        if role not in ("user", "assistant", "tool"):
-            role = "user"
+        if role in ("system", "developer"):
+            acp_role = role
+        elif role == "assistant":
+            acp_role = "assistant"
+        else:
+            # user, tool, function, or anything unexpected → user content.
+            acp_role = "user"
 
         # Flatten content
         if isinstance(m.content, list):
@@ -111,7 +134,7 @@ def _oai_messages_to_acp(messages: list[OAIMessage]) -> list[PromptMessage]:
         if m.role == "tool" and m.tool_call_id:
             content = f"[tool_result id={m.tool_call_id}]\n{content}"
 
-        result.append(PromptMessage(role=role, content=str(content)))
+        result.append(PromptMessage(role=acp_role, content=str(content)))
     return result
 
 
@@ -132,6 +155,24 @@ def _acp_tool_calls_to_oai(tool_calls: list[dict]) -> list[dict]:
 
 def _get_shim(request: Request) -> ShimService:
     return request.app.state.shim_service
+
+
+def _openai_error_response(mapped: MappedError) -> JSONResponse:
+    """Build a native OpenAI error ``JSONResponse`` from a classified error.
+
+    Args:
+        mapped: The classified error carrying the status code, message, native
+            ``type`` and optional ``Retry-After`` hint.
+
+    Returns:
+        A :class:`JSONResponse` with the OpenAI ``{"error": {...}}`` body, the
+        mapped HTTP status code, and a ``Retry-After`` header when available.
+    """
+    return JSONResponse(
+        status_code=mapped.status_code,
+        content=mapped.to_openai_error(),
+        headers=mapped.headers(),
+    )
 
 
 def _normalize_stop(stop: Any) -> Optional[list[str]]:
@@ -213,8 +254,11 @@ async def chat_completions(
             terminal=terminal,
         )
     except Exception as exc:
-        logger.error(f"OpenAI shim complete error: {exc}")
-        raise HTTPException(status_code=502, detail=str(exc))
+        mapped = classify_exception(exc)
+        logger.error(
+            f"OpenAI shim complete error (status={mapped.status_code}): {exc}"
+        )
+        return _openai_error_response(mapped)
 
     tool_calls = _acp_tool_calls_to_oai(result.get("tool_calls", []))
     finish_reason = "tool_calls" if tool_calls else result.get("finish_reason", "stop")
@@ -342,15 +386,26 @@ async def _stream_response(
                 break
 
             elif etype == "error":
-                message = event.get("message") or event.get("error") or "Unknown error"
-                error_payload = {"error": {"message": message, "type": "acp_error"}}
+                mapped = classify_event(event)
+                error_payload = {"error": {
+                    "message": mapped.message,
+                    "type": mapped.openai_type,
+                    "code": None,
+                    "param": None,
+                }}
                 yield f"data: {json.dumps(error_payload)}\n\n"
                 yield "data: [DONE]\n\n"
                 break
 
     except Exception as exc:
-        logger.error(f"OpenAI stream error: {exc}")
-        error_payload = {"error": {"message": str(exc), "type": "gateway_error"}}
+        mapped = classify_exception(exc)
+        logger.error(f"OpenAI stream error (status={mapped.status_code}): {exc}")
+        error_payload = {"error": {
+            "message": mapped.message,
+            "type": mapped.openai_type,
+            "code": None,
+            "param": None,
+        }}
         yield f"data: {json.dumps(error_payload)}\n\n"
         yield "data: [DONE]\n\n"
 
@@ -399,8 +454,10 @@ def _responses_input_to_acp(
     """
     messages: list[PromptMessage] = []
     if instructions:
-        # ACP has no dedicated system role; surface instructions as user text.
-        messages.append(PromptMessage(role="user", content=str(instructions)))
+        # The Responses API ``instructions`` field is system-level guidance.
+        # Preserve it as a distinct system role (rendered with a ``System:``
+        # label) rather than collapsing it into anonymous user text.
+        messages.append(PromptMessage(role="system", content=str(instructions)))
 
     if isinstance(input_value, str):
         messages.append(PromptMessage(role="user", content=input_value))
@@ -509,8 +566,11 @@ async def create_response(
             terminal=terminal,
         )
     except Exception as exc:
-        logger.error(f"OpenAI responses complete error: {exc}")
-        raise HTTPException(status_code=502, detail=str(exc))
+        mapped = classify_exception(exc)
+        logger.error(
+            f"OpenAI responses complete error (status={mapped.status_code}): {exc}"
+        )
+        return _openai_error_response(mapped)
 
     response_id = f"resp_{uuid.uuid4().hex[:24]}"
     return _build_response_object(
@@ -704,16 +764,19 @@ async def _responses_stream(
                 break
 
             elif etype == "error":
-                message = event.get("message") or event.get("error") or "Unknown error"
+                mapped = classify_event(event)
                 failed = base_response("failed")
-                failed["error"] = {"message": message, "type": "acp_error"}
+                failed["error"] = {"message": mapped.message, "type": mapped.openai_type}
                 yield sse("response.failed", {"response": failed})
                 break
 
     except Exception as exc:
-        logger.error(f"OpenAI responses stream error: {exc}")
+        mapped = classify_exception(exc)
+        logger.error(
+            f"OpenAI responses stream error (status={mapped.status_code}): {exc}"
+        )
         failed = base_response("failed")
-        failed["error"] = {"message": str(exc), "type": "gateway_error"}
+        failed["error"] = {"message": mapped.message, "type": mapped.openai_type}
         yield sse("response.failed", {"response": failed})
 
 

--- a/tests/unit/test_error_mapping.py
+++ b/tests/unit/test_error_mapping.py
@@ -1,0 +1,150 @@
+"""
+Unit tests for kiro.error_mapping.
+
+Verify that ACP/upstream failures classify into the correct HTTP status codes
+and into the OpenAI/Anthropic native error envelopes, including Retry-After
+extraction.
+"""
+from __future__ import annotations
+
+import pytest
+
+from kiro.acp_client import ACPError
+from kiro.error_mapping import (
+    MappedError,
+    classify_error,
+    classify_event,
+    classify_exception,
+)
+
+
+class TestClassifyErrorStatus:
+    """classify_error resolves the right HTTP status for each condition."""
+
+    @pytest.mark.parametrize("message", [
+        "Rate limit exceeded",
+        "rate-limited by upstream",
+        "Too Many Requests",
+        "request was throttled",
+        "quota exceeded for this account",
+        "upstream returned 429",
+    ])
+    def test_rate_limit_maps_to_429(self, message):
+        assert classify_error(message).status_code == 429
+
+    @pytest.mark.parametrize("message", [
+        "The service is overloaded",
+        "503 Service Unavailable",
+        "server is temporarily unavailable",
+        "model is at capacity, try again later",
+        "Anthropic 529 overloaded_error",
+    ])
+    def test_overloaded_maps_to_503(self, message):
+        assert classify_error(message).status_code == 503
+
+    @pytest.mark.parametrize("message", [
+        "ACP session/prompt timed out after 120s",
+        "upstream timeout",
+        "deadline exceeded",
+    ])
+    def test_timeout_maps_to_504(self, message):
+        assert classify_error(message).status_code == 504
+
+    @pytest.mark.parametrize("message", [
+        "kiro-cli subprocess exited",
+        "some unexpected internal failure",
+        "",
+    ])
+    def test_default_maps_to_502(self, message):
+        assert classify_error(message).status_code == 502
+
+
+class TestClassifyErrorTypes:
+    """Native error type strings are correct per API."""
+
+    def test_rate_limit_types(self):
+        mapped = classify_error("rate limit exceeded")
+        assert mapped.openai_type == "rate_limit_error"
+        assert mapped.anthropic_type == "rate_limit_error"
+
+    def test_overloaded_types(self):
+        mapped = classify_error("overloaded")
+        assert mapped.openai_type == "server_error"
+        assert mapped.anthropic_type == "overloaded_error"
+
+    def test_timeout_types(self):
+        mapped = classify_error("timed out")
+        assert mapped.openai_type == "server_error"
+        assert mapped.anthropic_type == "api_error"
+
+    def test_default_types(self):
+        mapped = classify_error("boom")
+        assert mapped.openai_type == "server_error"
+        assert mapped.anthropic_type == "api_error"
+
+
+class TestRetryAfter:
+    """Retry-After hints are extracted and surfaced as a header."""
+
+    @pytest.mark.parametrize("message,expected", [
+        ("rate limit exceeded, retry after 30", 30),
+        ("Too many requests; retry-after: 12", 12),
+        ("overloaded, try again in 5 seconds", 5),
+    ])
+    def test_extracts_retry_after(self, message, expected):
+        assert classify_error(message).retry_after == expected
+
+    def test_no_retry_after_when_absent(self):
+        assert classify_error("rate limit exceeded").retry_after is None
+
+    def test_header_present_when_retry_after(self):
+        mapped = classify_error("rate limit exceeded, retry after 7")
+        assert mapped.headers() == {"Retry-After": "7"}
+
+    def test_header_empty_when_no_retry_after(self):
+        assert classify_error("boom").headers() == {}
+
+
+class TestNativeEnvelopes:
+    """to_openai_error / to_anthropic_error render the documented shapes."""
+
+    def test_openai_envelope(self):
+        mapped = classify_error("rate limit exceeded")
+        body = mapped.to_openai_error()
+        assert set(body) == {"error"}
+        assert body["error"]["type"] == "rate_limit_error"
+        assert body["error"]["message"] == "rate limit exceeded"
+        assert body["error"]["code"] is None
+        assert body["error"]["param"] is None
+
+    def test_anthropic_envelope(self):
+        mapped = classify_error("the service is overloaded")
+        body = mapped.to_anthropic_error()
+        assert body["type"] == "error"
+        assert body["error"]["type"] == "overloaded_error"
+        assert body["error"]["message"] == "the service is overloaded"
+
+
+class TestClassifyExceptionAndEvent:
+    """classify_exception / classify_event read code/data and message."""
+
+    def test_classify_acp_exception_rate_limit(self):
+        exc = ACPError(-32000, "Too Many Requests")
+        assert classify_exception(exc).status_code == 429
+
+    def test_classify_exception_reads_data(self):
+        exc = ACPError(-32000, "upstream failure", data={"reason": "throttled"})
+        assert classify_exception(exc).status_code == 429
+
+    def test_classify_plain_exception_defaults_502(self):
+        assert classify_exception(RuntimeError("kaboom")).status_code == 502
+
+    def test_classify_event_uses_message(self):
+        mapped = classify_event({"type": "error", "message": "rate limit exceeded"})
+        assert mapped.status_code == 429
+        assert mapped.openai_type == "rate_limit_error"
+
+    def test_classify_event_falls_back_to_unknown(self):
+        mapped = classify_event({"type": "error"})
+        assert mapped.status_code == 502
+        assert mapped.message == "Unknown error"

--- a/tests/unit/test_routes_anthropic_shim.py
+++ b/tests/unit/test_routes_anthropic_shim.py
@@ -515,3 +515,152 @@ class TestAnthropicShimSamplingForwarding:
         assert kw["top_p"] == 0.4
         assert kw["top_k"] == 10
         assert kw["stop"] == ["STOP"]
+
+
+# ---------------------------------------------------------------------------
+# Error mapping (issue #44): ACP/upstream failures surface with the right HTTP
+# status and the Anthropic native error shape, in both modes.
+# ---------------------------------------------------------------------------
+
+from unittest.mock import AsyncMock, MagicMock
+
+from kiro.acp_client import ACPError
+
+
+def _anthropic_error_shim_complete(exc):
+    shim = MagicMock()
+    shim.available_models = MagicMock(return_value=[])
+    shim.complete = AsyncMock(side_effect=exc)
+    return shim
+
+
+def _anthropic_error_shim_stream(event):
+    shim = MagicMock()
+    shim.available_models = MagicMock(return_value=[])
+
+    async def _stream(*args, **kwargs):
+        yield event
+
+    shim.stream_tokens = _stream
+    return shim
+
+
+class TestAnthropicShimErrorMapping:
+    """Non-streaming + streaming error classification for the Anthropic shim."""
+
+    _MSG = {
+        "model": "claude-sonnet-4.6",
+        "max_tokens": 64,
+        "messages": [{"role": "user", "content": "hi"}],
+    }
+
+    def test_non_stream_rate_limit_returns_429(self, sync_client, anthropic_headers):
+        sync_client.app.state.shim_service = _anthropic_error_shim_complete(
+            ACPError(-32000, "Rate limit exceeded, retry after 15")
+        )
+        resp = sync_client.post("/v1/messages", json=self._MSG, headers=anthropic_headers)
+        assert resp.status_code == 429
+        body = resp.json()
+        assert body["type"] == "error"
+        assert body["error"]["type"] == "rate_limit_error"
+        assert resp.headers.get("retry-after") == "15"
+
+    def test_non_stream_overloaded_returns_503(self, sync_client, anthropic_headers):
+        sync_client.app.state.shim_service = _anthropic_error_shim_complete(
+            ACPError(-32000, "service is overloaded")
+        )
+        resp = sync_client.post("/v1/messages", json=self._MSG, headers=anthropic_headers)
+        assert resp.status_code == 503
+        assert resp.json()["error"]["type"] == "overloaded_error"
+
+    def test_non_stream_timeout_returns_504(self, sync_client, anthropic_headers):
+        sync_client.app.state.shim_service = _anthropic_error_shim_complete(
+            ACPError(-32000, "ACP session/prompt timed out after 120s")
+        )
+        resp = sync_client.post("/v1/messages", json=self._MSG, headers=anthropic_headers)
+        assert resp.status_code == 504
+        assert resp.json()["error"]["type"] == "api_error"
+
+    def test_non_stream_default_returns_502(self, sync_client, anthropic_headers):
+        sync_client.app.state.shim_service = _anthropic_error_shim_complete(
+            ACPError(-32000, "kiro-cli subprocess exited")
+        )
+        resp = sync_client.post("/v1/messages", json=self._MSG, headers=anthropic_headers)
+        assert resp.status_code == 502
+        assert resp.json()["error"]["type"] == "api_error"
+
+    def test_stream_rate_limit_error_type(self, sync_client, anthropic_headers):
+        sync_client.app.state.shim_service = _anthropic_error_shim_stream(
+            {"type": "error", "message": "rate limit exceeded", "code": -32000}
+        )
+        payload = {**self._MSG, "stream": True}
+        resp = sync_client.post("/v1/messages", json=payload, headers=anthropic_headers)
+        assert resp.status_code == 200
+        assert "event: error" in resp.text
+        assert '"type": "rate_limit_error"' in resp.text
+
+    def test_stream_overloaded_error_type(self, sync_client, anthropic_headers):
+        sync_client.app.state.shim_service = _anthropic_error_shim_stream(
+            {"type": "error", "message": "overloaded", "code": -32000}
+        )
+        payload = {**self._MSG, "stream": True}
+        resp = sync_client.post("/v1/messages", json=payload, headers=anthropic_headers)
+        assert resp.status_code == 200
+        assert '"type": "overloaded_error"' in resp.text
+
+
+# ---------------------------------------------------------------------------
+# System-role handling (issue #44): the Anthropic `system` field is preserved
+# as a distinct system role (no ad-hoc [system] user prefix).
+# ---------------------------------------------------------------------------
+
+class TestAnthropicShimSystemRole:
+    """The system prompt is carried as a distinct system role, not user text."""
+
+    def test_system_string_becomes_system_role(self, sync_client, anthropic_headers):
+        rec = _RecordingShim()
+        sync_client.app.state.shim_service = rec
+        payload = {
+            "model": "claude-sonnet-4.6",
+            "max_tokens": 64,
+            "system": "Be terse.",
+            "messages": [{"role": "user", "content": "hi"}],
+        }
+        resp = sync_client.post("/v1/messages", json=payload, headers=anthropic_headers)
+        assert resp.status_code == 200
+        msgs = rec.complete_kwargs[0]["messages"]
+        assert msgs[0].role == "system"
+        assert msgs[0].content == "Be terse."
+        # The legacy ad-hoc prefix must be gone.
+        assert "[system]" not in msgs[0].content
+
+    def test_system_block_list_flattened_into_system_role(self, sync_client, anthropic_headers):
+        rec = _RecordingShim()
+        sync_client.app.state.shim_service = rec
+        payload = {
+            "model": "claude-sonnet-4.6",
+            "max_tokens": 64,
+            "system": [
+                {"type": "text", "text": "Line A."},
+                {"type": "text", "text": "Line B."},
+            ],
+            "messages": [{"role": "user", "content": "hi"}],
+        }
+        resp = sync_client.post("/v1/messages", json=payload, headers=anthropic_headers)
+        assert resp.status_code == 200
+        msgs = rec.complete_kwargs[0]["messages"]
+        assert msgs[0].role == "system"
+        assert msgs[0].content == "Line A.\nLine B."
+
+    def test_no_system_means_no_system_message(self, sync_client, anthropic_headers):
+        rec = _RecordingShim()
+        sync_client.app.state.shim_service = rec
+        payload = {
+            "model": "claude-sonnet-4.6",
+            "max_tokens": 64,
+            "messages": [{"role": "user", "content": "hi"}],
+        }
+        resp = sync_client.post("/v1/messages", json=payload, headers=anthropic_headers)
+        assert resp.status_code == 200
+        msgs = rec.complete_kwargs[0]["messages"]
+        assert all(m.role != "system" for m in msgs)

--- a/tests/unit/test_routes_openai_shim.py
+++ b/tests/unit/test_routes_openai_shim.py
@@ -391,3 +391,178 @@ class TestOpenAIShimSamplingForwarding:
         resp = sync_client.post("/v1/responses", json=payload, headers=openai_headers)
         assert resp.status_code == 200
         assert rec.stream_kwargs[0]["top_p"] == 0.33
+
+
+# ---------------------------------------------------------------------------
+# Error mapping (issue #44): ACP/upstream failures surface with the right HTTP
+# status and the OpenAI native error shape, in both streaming and non-streaming
+# paths.
+# ---------------------------------------------------------------------------
+
+from kiro.acp_client import ACPError
+
+
+def _error_shim_complete(exc):
+    """Build a shim whose complete() raises ``exc``."""
+    shim = MagicMock()
+    shim.available_models = MagicMock(return_value=[])
+    shim.complete = AsyncMock(side_effect=exc)
+    return shim
+
+
+def _error_shim_stream(event):
+    """Build a shim whose stream_tokens() emits a single error ``event``."""
+    shim = MagicMock()
+    shim.available_models = MagicMock(return_value=[])
+
+    async def _stream(*args, **kwargs):
+        yield event
+
+    shim.stream_tokens = _stream
+    return shim
+
+
+class TestOpenAIShimErrorMapping:
+    """Non-streaming + streaming error classification for the OpenAI shim."""
+
+    _CHAT = {"model": "claude-sonnet-4.6", "messages": [{"role": "user", "content": "hi"}]}
+
+    def test_chat_non_stream_rate_limit_returns_429(self, sync_client, openai_headers):
+        sync_client.app.state.shim_service = _error_shim_complete(
+            ACPError(-32000, "Rate limit exceeded, retry after 30")
+        )
+        resp = sync_client.post("/v1/chat/completions", json=self._CHAT, headers=openai_headers)
+        assert resp.status_code == 429
+        body = resp.json()
+        assert body["error"]["type"] == "rate_limit_error"
+        assert resp.headers.get("retry-after") == "30"
+
+    def test_chat_non_stream_overloaded_returns_503(self, sync_client, openai_headers):
+        sync_client.app.state.shim_service = _error_shim_complete(
+            ACPError(-32000, "service is overloaded")
+        )
+        resp = sync_client.post("/v1/chat/completions", json=self._CHAT, headers=openai_headers)
+        assert resp.status_code == 503
+        assert resp.json()["error"]["type"] == "server_error"
+
+    def test_chat_non_stream_timeout_returns_504(self, sync_client, openai_headers):
+        sync_client.app.state.shim_service = _error_shim_complete(
+            ACPError(-32000, "ACP session/prompt timed out after 120s")
+        )
+        resp = sync_client.post("/v1/chat/completions", json=self._CHAT, headers=openai_headers)
+        assert resp.status_code == 504
+
+    def test_chat_non_stream_default_returns_502(self, sync_client, openai_headers):
+        sync_client.app.state.shim_service = _error_shim_complete(
+            ACPError(-32000, "kiro-cli subprocess exited")
+        )
+        resp = sync_client.post("/v1/chat/completions", json=self._CHAT, headers=openai_headers)
+        assert resp.status_code == 502
+        assert resp.json()["error"]["type"] == "server_error"
+
+    def test_chat_stream_rate_limit_error_type(self, sync_client, openai_headers):
+        sync_client.app.state.shim_service = _error_shim_stream(
+            {"type": "error", "message": "rate limit exceeded", "code": -32000}
+        )
+        payload = {**self._CHAT, "stream": True}
+        resp = sync_client.post("/v1/chat/completions", json=payload, headers=openai_headers)
+        assert resp.status_code == 200  # SSE body already started
+        assert '"type": "rate_limit_error"' in resp.text
+        assert "data: [DONE]" in resp.text
+
+    def test_responses_non_stream_rate_limit_returns_429(self, sync_client, openai_headers):
+        sync_client.app.state.shim_service = _error_shim_complete(
+            ACPError(-32000, "Too Many Requests")
+        )
+        resp = sync_client.post(
+            "/v1/responses", json={"model": "claude-sonnet-4.6", "input": "hi"},
+            headers=openai_headers,
+        )
+        assert resp.status_code == 429
+        assert resp.json()["error"]["type"] == "rate_limit_error"
+
+    def test_responses_stream_error_uses_mapped_type(self, sync_client, openai_headers):
+        sync_client.app.state.shim_service = _error_shim_stream(
+            {"type": "error", "message": "overloaded", "code": -32000}
+        )
+        payload = {"model": "claude-sonnet-4.6", "input": "hi", "stream": True}
+        resp = sync_client.post("/v1/responses", json=payload, headers=openai_headers)
+        assert resp.status_code == 200
+        assert "event: response.failed" in resp.text
+        assert '"type": "server_error"' in resp.text
+
+
+# ---------------------------------------------------------------------------
+# System-role handling (issue #44): system/developer roles are preserved
+# distinctly (not flattened to anonymous user text), and instructions map to a
+# system role in the Responses API.
+# ---------------------------------------------------------------------------
+
+class TestOpenAIShimSystemRole:
+    """system/developer provenance is preserved through to ACP messages."""
+
+    def test_chat_preserves_system_and_developer_roles(self, sync_client, openai_headers):
+        rec = _RecordingShim()
+        sync_client.app.state.shim_service = rec
+        payload = {
+            "model": "claude-sonnet-4.6",
+            "messages": [
+                {"role": "system", "content": "Be terse."},
+                {"role": "developer", "content": "Use Python."},
+                {"role": "user", "content": "hi"},
+            ],
+        }
+        resp = sync_client.post("/v1/chat/completions", json=payload, headers=openai_headers)
+        assert resp.status_code == 200
+        roles = [(m.role, m.content) for m in rec.complete_kwargs[0]["messages"]]
+        assert roles == [
+            ("system", "Be terse."),
+            ("developer", "Use Python."),
+            ("user", "hi"),
+        ]
+
+    def test_chat_multiple_system_messages_not_merged(self, sync_client, openai_headers):
+        rec = _RecordingShim()
+        sync_client.app.state.shim_service = rec
+        payload = {
+            "model": "claude-sonnet-4.6",
+            "messages": [
+                {"role": "system", "content": "Rule one."},
+                {"role": "system", "content": "Rule two."},
+                {"role": "user", "content": "hi"},
+            ],
+        }
+        resp = sync_client.post("/v1/chat/completions", json=payload, headers=openai_headers)
+        assert resp.status_code == 200
+        system_msgs = [m.content for m in rec.complete_kwargs[0]["messages"] if m.role == "system"]
+        assert system_msgs == ["Rule one.", "Rule two."]
+
+    def test_tool_role_does_not_break_and_maps_to_user(self, sync_client, openai_headers):
+        rec = _RecordingShim()
+        sync_client.app.state.shim_service = rec
+        payload = {
+            "model": "claude-sonnet-4.6",
+            "messages": [
+                {"role": "user", "content": "weather?"},
+                {"role": "tool", "tool_call_id": "abc", "content": "sunny"},
+            ],
+        }
+        resp = sync_client.post("/v1/chat/completions", json=payload, headers=openai_headers)
+        assert resp.status_code == 200
+        msgs = rec.complete_kwargs[0]["messages"]
+        assert msgs[-1].role == "user"
+        assert "[tool_result id=abc]" in msgs[-1].content
+
+    def test_responses_instructions_map_to_system_role(self, sync_client, openai_headers):
+        rec = _RecordingShim()
+        sync_client.app.state.shim_service = rec
+        payload = {
+            "model": "claude-sonnet-4.6",
+            "instructions": "You are helpful.",
+            "input": "hi",
+        }
+        resp = sync_client.post("/v1/responses", json=payload, headers=openai_headers)
+        assert resp.status_code == 200
+        msgs = rec.complete_kwargs[0]["messages"]
+        assert msgs[0].role == "system"
+        assert msgs[0].content == "You are helpful."


### PR DESCRIPTION
Closes #44

## Summary
Addresses the two fidelity gaps in #44, consistently across **both shims** and **both** streaming and non-streaming paths.

### 1. Error mapping
New `kiro/error_mapping.py` classifies ACP/upstream failures into the correct HTTP status and each API's **native** error envelope (no more blanket `502 {"detail": ...}`):

| Condition | Status | OpenAI `type` | Anthropic `type` |
|---|---|---|---|
| rate limit / throttle / quota / 429 | `429` | `rate_limit_error` | `rate_limit_error` |
| overloaded / unavailable / capacity | `503` | `server_error` | `overloaded_error` |
| timeout / deadline | `504` | `server_error` | `api_error` |
| default | `502` | `server_error` | `api_error` |

- Non-streaming: mapped status + native body, plus a `Retry-After` header when the upstream message carries a retry hint.
- Streaming: the SSE stream is already `200`, so the mapped error `type` is carried in the terminal error event (OpenAI error chunk + `[DONE]`, Responses `response.failed`, or Anthropic `error`).
- ACP error events now propagate the JSON-RPC `code`/`data` so classification works identically in both modes.

### 2. System / developer role fidelity
- `PromptMessage` gains a `developer` role.
- OpenAI `system`/`developer` are preserved distinctly (rendered as `System:` / `Developer:` labels, order and multiplicity kept); `tool`/unknown roles map to `user` (also fixes a latent `tool`-role validation crash). Responses `instructions` → `system`.
- Anthropic `system` (string or block list) is carried as a real `system` role instead of the ad-hoc `[system]` user prefix.

## Tests
- New `tests/unit/test_error_mapping.py` (classifier + native envelopes + Retry-After).
- Error-mapping and system-role route tests added to both shim test modules (non-streaming + streaming).
- Full suite: **348 passed, 1 skipped** (pre-existing skip).

## Docs
- `README.md`: new "Error handling" and "System & developer roles" sections.
- `AGENTS.md`: updated internal event contract (`code`/`data`) plus "Error Mapping" and "System & developer roles" guidance.

## Acceptance criteria
- [x] Transient/rate-limit errors surface with correct status codes and native error shapes for both shims.
- [x] System-role handling behavior is defined, tested, and documented.
