### PR TITLE
fix: tool-call handling — stop harness hang + surface shell output

### DIFF
--- a/kiro/acp_client.py
+++ b/kiro/acp_client.py
@@ -48,6 +48,7 @@ from __future__ import annotations
 import asyncio
 import json
 import os
+import re as _re
 import uuid
 from asyncio import Queue
 from typing import Any, AsyncIterator, Optional
@@ -183,13 +184,24 @@ def _format_tool_args(arguments: dict) -> str:
 
 
 def _summarize_json_output(payload: Any) -> str:
-    """Summarise a structured tool result (grep/glob) into a one-line string.
+    """Summarise a structured tool result into activity text.
+
+    Handles the ``Json`` result shapes kiro-cli emits on a ``tool_call_update``:
+
+    * **grep** — ``{"numMatches", "numFiles", …}`` → a one-line match summary.
+    * **glob** — ``{"filePaths"|"totalFiles", …}`` → a one-line file-count summary.
+    * **execute (shell)** — ``{"exit_status", "stdout", "stderr"}`` → the command's
+      stdout/stderr text, with a ``[exit: …]`` marker appended when the command
+      failed (non-zero exit) so a failing command is visible even with no output.
+      Verified against a live kiro-cli 2.12.0 probe: shell output arrives as this
+      ``Json`` shape, **not** as a ``Text`` item — so without this branch the
+      output (and any failure) is silently dropped from the activity view.
 
     Args:
         payload: The ``Json`` value from a tool ``rawOutput`` item.
 
     Returns:
-        A concise summary, or ``""`` for shapes we don't summarise (avoids
+        The summary/output text, or ``""`` for shapes we don't render (avoids
         dumping arbitrary JSON into the reasoning stream).
     """
     if not isinstance(payload, dict):
@@ -209,6 +221,19 @@ def _summarize_json_output(payload: Any) -> str:
         if count is None:
             count = len(payload.get("filePaths") or [])
         return f"{count} file(s) found"
+    # execute (shell): {"exit_status": "exit status: N", "stdout": ..., "stderr": ...}
+    if "exit_status" in payload or "stdout" in payload or "stderr" in payload:
+        stdout = str(payload.get("stdout") or "").rstrip()
+        stderr = str(payload.get("stderr") or "").rstrip()
+        segments = [seg for seg in (stdout, stderr) if seg]
+        body = "\n".join(segments)
+        exit_status = str(payload.get("exit_status") or "").strip()
+        match = _re.search(r"-?\d+", exit_status)
+        exit_code = int(match.group()) if match else 0
+        if exit_code != 0:
+            marker = f"[exit: {exit_code}]"
+            body = f"{body}\n{marker}" if body else marker
+        return body
     return ""
 
 

--- a/kiro/routes_anthropic_shim.py
+++ b/kiro/routes_anthropic_shim.py
@@ -32,6 +32,7 @@ Fixes
 from __future__ import annotations
 
 import json
+import re as _re
 import time
 import uuid
 from typing import Any, AsyncIterator, Optional
@@ -52,6 +53,30 @@ from kiro.shim_service import ShimService
 from kiro.tokenizer import estimate_request_tokens, normalize_usage
 
 router = APIRouter(tags=["Anthropic Shim"])
+
+_INVALID_TOOL_NAME_CHARS = _re.compile(r"[^a-zA-Z0-9_-]")
+
+
+def _sanitize_tool_name(name: str) -> str:
+    """Sanitize a tool name to be a valid Anthropic tool-use name.
+
+    kiro-cli's built-in tools emit descriptive titles like "Running: ls -la /tmp"
+    or "Reading listing tmp" as tool names. Anthropic requires names matching
+    ``^[a-zA-Z0-9_-]+$``; invalid characters are replaced with ``_`` and
+    consecutive underscores are collapsed.
+
+    Args:
+        name: Raw tool call title from kiro-cli.
+
+    Returns:
+        Sanitized, API-valid tool name (falls back to ``kiro_tool`` when the
+        result is empty after cleaning).
+    """
+    if not name:
+        return "kiro_tool"
+    sanitized = _INVALID_TOOL_NAME_CHARS.sub("_", name)
+    sanitized = _re.sub(r"_+", "_", sanitized).strip("_")
+    return sanitized or "kiro_tool"
 
 
 # ---------------------------------------------------------------------------
@@ -397,11 +422,15 @@ async def create_message(
         content_blocks.append({
             "type": "tool_use",
             "id": tc.get("id", str(uuid.uuid4())),
-            "name": tc.get("name", ""),
+            "name": _sanitize_tool_name(tc.get("name", "")),
             "input": tc.get("arguments", {}),
         })
 
-    if result.get("tool_calls"):
+    if result.get("tool_calls") and not result["content"]:
+        # Only use stop_reason=tool_use when tool calls are present AND no text
+        # content was produced. When kiro-cli runs its own built-in tools and
+        # then streams a text answer, both are present — in that case the turn
+        # is complete and the harness must not loop waiting for tool results.
         stop_reason = "tool_use"
     else:
         # Map the internal finish_reason to Anthropic vocabulary so gateway-side
@@ -589,7 +618,7 @@ async def _stream_response(
 
             elif etype == "tool_call":
                 tc_id = event.get("id", str(uuid.uuid4()))
-                name = event.get("name", "")
+                name = _sanitize_tool_name(event.get("name", ""))
                 arguments = event.get("arguments", {})
                 collected_tool_calls[tc_id] = {"name": name, "arguments": arguments}
 
@@ -639,7 +668,13 @@ async def _stream_response(
                     yield sse("content_block_stop", {"type": "content_block_stop", "index": block_idx})
 
                 usage = event.get("usage", {}) or {}
-                stop_reason = "tool_use" if active_tool_blocks else (
+                # Only use stop_reason=tool_use when tool blocks were emitted AND
+                # no text content was streamed. When kiro-cli runs its own built-in
+                # tools and then produces a text answer, active_tool_blocks is
+                # non-empty but the turn is complete — returning tool_use would
+                # cause Claude Code / Kilo Code to loop waiting for tool results
+                # that kiro-cli already resolved internally.
+                stop_reason = "tool_use" if active_tool_blocks and not text_acc else (
                     event.get("finish_reason") or "end_turn"
                 )
                 # Normalise OpenAI-style finish reasons to Anthropic vocabulary.

--- a/kiro/routes_openai_shim.py
+++ b/kiro/routes_openai_shim.py
@@ -197,6 +197,35 @@ def _oai_messages_to_acp(messages: list[OAIMessage]) -> list[PromptMessage]:
     return result
 
 
+import re as _re
+
+_INVALID_TOOL_NAME_CHARS = _re.compile(r"[^a-zA-Z0-9_-]")
+
+
+def _sanitize_tool_name(name: str) -> str:
+    """Sanitize a tool name to be a valid OpenAI / Anthropic function name.
+
+    kiro-cli's built-in tools emit descriptive titles like "Running: ls -la /tmp"
+    or "Reading listing tmp" as tool names. These contain spaces, colons, slashes
+    and other characters that are rejected by harness function-name validators
+    (``^[a-zA-Z0-9_-]+$``). This function replaces every invalid character with
+    ``_`` and collapses consecutive underscores, ensuring the name is always
+    accepted without changing its recognisable meaning.
+
+    Args:
+        name: Raw tool call title from kiro-cli.
+
+    Returns:
+        Sanitized, API-valid function name (falls back to ``kiro_tool`` when
+        the result is empty after cleaning).
+    """
+    if not name:
+        return "kiro_tool"
+    sanitized = _INVALID_TOOL_NAME_CHARS.sub("_", name)
+    sanitized = _re.sub(r"_+", "_", sanitized).strip("_")
+    return sanitized or "kiro_tool"
+
+
 def _acp_tool_calls_to_oai(tool_calls: list[dict]) -> list[dict]:
     """Convert ACP ToolCall list to OpenAI tool_calls format."""
     result = []
@@ -205,7 +234,7 @@ def _acp_tool_calls_to_oai(tool_calls: list[dict]) -> list[dict]:
             "id": tc.get("id", str(uuid.uuid4())),
             "type": "function",
             "function": {
-                "name": tc.get("name", ""),
+                "name": _sanitize_tool_name(tc.get("name", "")),
                 "arguments": json.dumps(tc.get("arguments", {})),
             },
         })
@@ -403,7 +432,16 @@ async def chat_completions(
         return _openai_error_response(mapped)
 
     tool_calls = _acp_tool_calls_to_oai(result.get("tool_calls", []))
-    finish_reason = "tool_calls" if tool_calls else result.get("finish_reason", "stop")
+    # Only use finish_reason=tool_calls when tool calls are present AND no text
+    # content was produced. When kiro-cli runs its own built-in tools and then
+    # produces a text answer, both are present — in that case the turn is
+    # complete and the harness must not loop waiting for tool results that
+    # kiro-cli already resolved internally.
+    finish_reason = (
+        "tool_calls"
+        if tool_calls and not result.get("content")
+        else result.get("finish_reason", "stop")
+    )
 
     usage = normalize_usage(
         result.get("usage"),
@@ -550,7 +588,7 @@ async def _stream_response(
 
             elif etype == "tool_call":
                 tc_id = event.get("id", str(uuid.uuid4()))
-                name = event.get("name", "")
+                name = _sanitize_tool_name(event.get("name", ""))
                 arguments = event.get("arguments", {})
                 collected_tool_calls[tc_id] = {"name": name, "arguments": arguments}
                 if tc_id not in active_tool_idx:
@@ -574,8 +612,17 @@ async def _stream_response(
                     }]})
 
             elif etype == "done":
-                finish_reason = "tool_calls" if active_tool_idx else (
-                    event.get("finish_reason") or "stop"
+                # Only use finish_reason=tool_calls when tool calls were emitted
+                # AND no text content was streamed. When kiro-cli runs its own
+                # built-in tools mid-turn and also produces a text answer,
+                # active_tool_idx is non-empty but the turn is complete —
+                # returning tool_calls would cause harnesses (Claude Code,
+                # OpenCode) to loop waiting for tool results that kiro-cli
+                # already resolved internally.
+                finish_reason = (
+                    "tool_calls"
+                    if active_tool_idx and not text_acc
+                    else (event.get("finish_reason") or "stop")
                 )
                 yield chunk({}, finish_reason=finish_reason)
                 if include_usage:
@@ -1096,7 +1143,7 @@ async def _responses_stream(
                     text_item_open = False
 
                 tc_id = event.get("id", f"call_{uuid.uuid4().hex[:24]}")
-                name = event.get("name", "")
+                name = _sanitize_tool_name(event.get("name", ""))
                 arguments = event.get("arguments", {})
                 if tc_id not in tool_output_index:
                     output_index += 1

--- a/tests/unit/test_acp_client.py
+++ b/tests/unit/test_acp_client.py
@@ -1660,6 +1660,56 @@ class TestStructuredToolRendering:
         assert out == "2 match(es) in 1 file(s)"
         assert "matches" not in out
 
+    # --- execute (shell) tool output (verified against a live kiro-cli 2.12.0
+    # probe: shell output arrives as {"Json": {"exit_status","stdout","stderr"}},
+    # not a "Text" item — so it must be extracted, or the output is lost). ---
+
+    def test_execute_json_stdout_extracted(self):
+        """A successful shell command's stdout is extracted from the Json shape."""
+        out = ACPClient._extract_tool_output({"items": [{"Json": {
+            "exit_status": "exit status: 0", "stdout": "42\n", "stderr": ""}}]})
+        assert out == "42"
+
+    def test_execute_json_stderr_and_exit_code_on_failure(self):
+        """A failing command surfaces stderr and an [exit: N] marker."""
+        out = ACPClient._extract_tool_output({"items": [{"Json": {
+            "exit_status": "exit status: 127",
+            "stdout": "",
+            "stderr": "bash: line 1: nope: command not found\n"}}]})
+        assert "command not found" in out
+        assert "[exit: 127]" in out
+
+    def test_execute_json_failure_with_no_output_shows_marker(self):
+        """A command that fails silently still shows the exit marker."""
+        out = ACPClient._extract_tool_output({"items": [{"Json": {
+            "exit_status": "exit status: 1", "stdout": "", "stderr": ""}}]})
+        assert out == "[exit: 1]"
+
+    def test_execute_json_success_no_exit_marker(self):
+        """A zero-exit command shows output without an exit marker."""
+        out = ACPClient._extract_tool_output({"items": [{"Json": {
+            "exit_status": "exit status: 0", "stdout": "ok", "stderr": ""}}]})
+        assert out == "ok"
+        assert "exit:" not in out
+
+    def test_execute_output_rendered_as_fenced_block(self):
+        """render_tool_activity wraps execute output in a fenced block."""
+        out = ACPClient._extract_tool_output({"items": [{"Json": {
+            "exit_status": "exit status: 0", "stdout": "42\n", "stderr": ""}}]})
+        rendered = render_tool_activity(
+            {"type": "tool_call_update", "kind": "execute", "output": out})
+        assert "```\n42\n```" in rendered
+
+    def test_execute_failure_rendered_with_marker(self):
+        """A failed command renders stderr + exit marker in a fenced block."""
+        out = ACPClient._extract_tool_output({"items": [{"Json": {
+            "exit_status": "exit status: 127", "stdout": "",
+            "stderr": "bash: nope: command not found\n"}}]})
+        rendered = render_tool_activity(
+            {"type": "tool_call_update", "kind": "execute", "output": out})
+        assert "command not found" in rendered
+        assert "[exit: 127]" in rendered
+
 
 # ---------------------------------------------------------------------------
 # Multi-turn prompt serialization (issue #43): the stateless gateway carries

--- a/tests/unit/test_routes_anthropic_shim.py
+++ b/tests/unit/test_routes_anthropic_shim.py
@@ -1215,7 +1215,13 @@ class TestAnthropicShimToolSurfacingGate:
         resp = sync_client.post("/v1/messages", json=self._MSG, headers=anthropic_headers)
         body = resp.json()
         assert any(b["type"] == "tool_use" for b in body["content"])
-        assert body["stop_reason"] == "tool_use"
+        # Tool name is sanitized (spaces → underscores).
+        tool_block = next(b for b in body["content"] if b["type"] == "tool_use")
+        assert tool_block["name"] == "Fetching_web_content"
+        # _ToolEmittingACP returns content AND tool_calls; when content is
+        # present the turn is complete — stop_reason must be "end_turn", not
+        # "tool_use" (harnesses must not loop on tool execution).
+        assert body["stop_reason"] == "end_turn"
 
     def test_stream_default_suppresses_tool_use(self, sync_client, anthropic_headers):
         sync_client.app.state.shim_service = _ShimService(_ToolEmittingACP())
@@ -1228,8 +1234,129 @@ class TestAnthropicShimToolSurfacingGate:
         sync_client.app.state.shim_service = _ShimService(_ToolEmittingACP())
         payload = {**self._MSG, "stream": True}
         resp = sync_client.post("/v1/messages", json=payload, headers=anthropic_headers)
+        # Tool block is emitted (name sanitized).
         assert '"tool_use"' in resp.text
-        assert "Fetching web content" in resp.text
+        assert "Fetching_web_content" in resp.text
+        # Content was also streamed, so stop_reason must be "end_turn" not
+        # "tool_use" — harnesses must not loop on tool execution.
+        assert '"stop_reason": "end_turn"' in resp.text
+
+
+# ---------------------------------------------------------------------------
+# Regression tests: stop_reason=tool_use only when tool blocks are present
+# AND no text content was produced. When kiro-cli runs its own tools and then
+# returns a text answer, stop_reason must be "end_turn" so harnesses don't
+# hang waiting for tool execution that kiro-cli already performed internally.
+# Tool names must be sanitized to valid Anthropic tool identifiers.
+# ---------------------------------------------------------------------------
+
+class _PureToolUseACP:
+    """Stub that returns tool_use blocks with NO text content."""
+
+    available_models: list = []
+
+    async def new_session(self, capabilities=None, cwd=None, model=None):
+        return "s"
+
+    async def prompt(self, params):
+        return {
+            "content": "",
+            "finish_reason": "tool_calls",
+            "tool_calls": [{"id": "toolu_01", "name": "my_function", "arguments": {"x": 1}}],
+            "usage": {},
+        }
+
+    async def prompt_stream(self, params):
+        yield {"type": "tool_call", "id": "toolu_01", "name": "my_function", "arguments": {"x": 1}}
+        yield {"type": "done", "finish_reason": "tool_calls"}
+
+
+class _DirtyNameToolACP:
+    """Stub with invalid tool names: spaces, colons, slashes."""
+
+    available_models: list = []
+
+    async def new_session(self, capabilities=None, cwd=None, model=None):
+        return "s"
+
+    async def prompt(self, params):
+        return {
+            "content": "",
+            "finish_reason": "tool_calls",
+            "tool_calls": [
+                {"id": "c1", "name": "Running: ls -la /tmp", "arguments": {}},
+                {"id": "c2", "name": "", "arguments": {}},
+            ],
+            "usage": {},
+        }
+
+    async def prompt_stream(self, params):
+        yield {"type": "tool_call", "id": "c1", "name": "Running: ls -la /tmp", "arguments": {}}
+        yield {"type": "done", "finish_reason": "tool_calls"}
+
+
+class TestAnthropicToolCallStopReasonRegression:
+    """Regression: stop_reason=tool_use only without text; names are sanitized."""
+
+    _MSG = {
+        "model": "claude-sonnet-4.6", "max_tokens": 64,
+        "messages": [{"role": "user", "content": "q"}],
+    }
+
+    def test_non_stream_pure_tool_use_emits_tool_use(self, sync_client, anthropic_headers, monkeypatch):
+        """A turn with tool_use and NO content should use stop_reason=tool_use."""
+        monkeypatch.setattr(_settings, "ACP_SURFACE_TOOL_CALLS", True)
+        sync_client.app.state.shim_service = _ShimService(_PureToolUseACP())
+        resp = sync_client.post("/v1/messages", json=self._MSG, headers=anthropic_headers)
+        assert resp.json()["stop_reason"] == "tool_use"
+
+    def test_stream_pure_tool_use_emits_tool_use(self, sync_client, anthropic_headers, monkeypatch):
+        """Streaming pure tool_use (no text) should end with stop_reason=tool_use."""
+        monkeypatch.setattr(_settings, "ACP_SURFACE_TOOL_CALLS", True)
+        sync_client.app.state.shim_service = _ShimService(_PureToolUseACP())
+        payload = {**self._MSG, "stream": True}
+        resp = sync_client.post("/v1/messages", json=payload, headers=anthropic_headers)
+        assert '"stop_reason": "tool_use"' in resp.text
+
+    def test_non_stream_tool_use_with_content_emits_end_turn(self, sync_client, anthropic_headers, monkeypatch):
+        """A turn with tool_use AND text content should use stop_reason=end_turn."""
+        monkeypatch.setattr(_settings, "ACP_SURFACE_TOOL_CALLS", True)
+        sync_client.app.state.shim_service = _ShimService(_ToolEmittingACP())
+        resp = sync_client.post("/v1/messages", json=self._MSG, headers=anthropic_headers)
+        assert resp.json()["stop_reason"] == "end_turn", (
+            "stop_reason must be end_turn when content is present alongside tool_use "
+            "(kiro-cli already ran the tool and returned the answer)"
+        )
+
+    def test_stream_tool_use_with_content_emits_end_turn(self, sync_client, anthropic_headers, monkeypatch):
+        """Streaming a turn with tool_use + content must end with stop_reason=end_turn."""
+        monkeypatch.setattr(_settings, "ACP_SURFACE_TOOL_CALLS", True)
+        sync_client.app.state.shim_service = _ShimService(_ToolEmittingACP())
+        payload = {**self._MSG, "stream": True}
+        resp = sync_client.post("/v1/messages", json=payload, headers=anthropic_headers)
+        assert '"stop_reason": "end_turn"' in resp.text
+        assert '"stop_reason": "tool_use"' not in resp.text
+
+    def test_tool_name_sanitization(self, sync_client, anthropic_headers, monkeypatch):
+        """kiro-cli tool names with spaces/colons/slashes are sanitized."""
+        monkeypatch.setattr(_settings, "ACP_SURFACE_TOOL_CALLS", True)
+        sync_client.app.state.shim_service = _ShimService(_DirtyNameToolACP())
+        resp = sync_client.post("/v1/messages", json=self._MSG, headers=anthropic_headers)
+        tool_blocks = [b for b in resp.json()["content"] if b["type"] == "tool_use"]
+        names = [b["name"] for b in tool_blocks]
+        assert all(" " not in n for n in names), f"Tool names still contain spaces: {names}"
+        assert all(":" not in n for n in names), f"Tool names still contain colons: {names}"
+        # Empty name falls back to kiro_tool.
+        assert "kiro_tool" in names
+
+    def test_stream_tool_name_sanitization(self, sync_client, anthropic_headers, monkeypatch):
+        """Streaming tool names must also be sanitized."""
+        monkeypatch.setattr(_settings, "ACP_SURFACE_TOOL_CALLS", True)
+        sync_client.app.state.shim_service = _ShimService(_DirtyNameToolACP())
+        payload = {**self._MSG, "stream": True}
+        resp = sync_client.post("/v1/messages", json=payload, headers=anthropic_headers)
+        assert "Running: ls" not in resp.text
+        assert "Running_ls" in resp.text or "Running__ls" in resp.text
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_routes_openai_shim.py
+++ b/tests/unit/test_routes_openai_shim.py
@@ -1260,8 +1260,13 @@ class TestOpenAIShimToolSurfacingGate:
         sync_client.app.state.shim_service = _ShimService(_ToolEmittingACP())
         resp = sync_client.post("/v1/chat/completions", json=self._CHAT, headers=openai_headers)
         choice = resp.json()["choices"][0]
-        assert choice["finish_reason"] == "tool_calls"
-        assert choice["message"]["tool_calls"][0]["function"]["name"] == "Fetching web content"
+        # _ToolEmittingACP returns both content AND tool_calls; when content is
+        # present the turn is complete so finish_reason must be "stop", not
+        # "tool_calls" (a harness would otherwise loop waiting to execute a tool
+        # kiro-cli already ran internally).
+        assert choice["finish_reason"] == "stop"
+        # Tool name is sanitized: spaces → underscores.
+        assert choice["message"]["tool_calls"][0]["function"]["name"] == "Fetching_web_content"
 
     def test_chat_stream_default_suppresses_tool_calls(self, sync_client, openai_headers):
         sync_client.app.state.shim_service = _ShimService(_ToolEmittingACP())
@@ -1275,8 +1280,133 @@ class TestOpenAIShimToolSurfacingGate:
         sync_client.app.state.shim_service = _ShimService(_ToolEmittingACP())
         payload = {**self._CHAT, "stream": True}
         resp = sync_client.post("/v1/chat/completions", json=payload, headers=openai_headers)
+        # Tool call chunk is emitted (name sanitized).
         assert '"tool_calls"' in resp.text
-        assert "Fetching web content" in resp.text
+        assert "Fetching_web_content" in resp.text
+        # Content was also streamed, so finish_reason must be "stop" not
+        # "tool_calls" — harnesses must not loop on tool execution.
+        assert '"finish_reason": "stop"' in resp.text
+
+
+# ---------------------------------------------------------------------------
+# Regression tests: finish_reason=tool_calls only when tool calls are present
+# AND no text content was produced. When kiro-cli runs its own tools and then
+# returns a text answer, finish_reason must be "stop" so harnesses don't hang
+# waiting for tool execution that kiro-cli already performed internally.
+# Tool names must be sanitized to valid function identifiers.
+# ---------------------------------------------------------------------------
+
+class _PureToolCallACP:
+    """Stub that returns tool calls with NO text content (pure tool-call turn)."""
+
+    available_models: list = []
+
+    async def new_session(self, capabilities=None, cwd=None, model=None):
+        return "s"
+
+    async def prompt(self, params):
+        return {
+            "content": "",
+            "finish_reason": "tool_calls",
+            "tool_calls": [{"id": "c1", "name": "my_function", "arguments": {"x": 1}}],
+            "usage": {},
+        }
+
+    async def prompt_stream(self, params):
+        yield {"type": "tool_call", "id": "c1", "name": "my_function", "arguments": {"x": 1}}
+        yield {"type": "done", "finish_reason": "tool_calls"}
+
+
+class _DirtyNameToolACP:
+    """Stub with invalid tool names: spaces, colons, slashes."""
+
+    available_models: list = []
+
+    async def new_session(self, capabilities=None, cwd=None, model=None):
+        return "s"
+
+    async def prompt(self, params):
+        return {
+            "content": "",
+            "finish_reason": "tool_calls",
+            "tool_calls": [
+                {"id": "c1", "name": "Running: ls -la /tmp", "arguments": {}},
+                {"id": "c2", "name": "Reading listing tmp", "arguments": {}},
+                {"id": "c3", "name": "  !!invalid!!  ", "arguments": {}},
+                {"id": "c4", "name": "", "arguments": {}},
+            ],
+            "usage": {},
+        }
+
+    async def prompt_stream(self, params):
+        yield {"type": "tool_call", "id": "c1", "name": "Running: ls -la /tmp", "arguments": {}}
+        yield {"type": "tool_call", "id": "c2", "name": "Reading listing tmp", "arguments": {}}
+        yield {"type": "done", "finish_reason": "tool_calls"}
+
+
+class TestOpenAIToolCallFinishReasonRegression:
+    """Regression: finish_reason=tool_calls only without text; names are sanitized."""
+
+    _CHAT = {"model": "claude-sonnet-4.6", "messages": [{"role": "user", "content": "q"}]}
+
+    def test_non_stream_pure_tool_call_emits_tool_calls(self, sync_client, openai_headers, monkeypatch):
+        """A turn with tool calls and NO content should use finish_reason=tool_calls."""
+        monkeypatch.setattr(_settings, "ACP_SURFACE_TOOL_CALLS", True)
+        sync_client.app.state.shim_service = _ShimService(_PureToolCallACP())
+        resp = sync_client.post("/v1/chat/completions", json=self._CHAT, headers=openai_headers)
+        choice = resp.json()["choices"][0]
+        assert choice["finish_reason"] == "tool_calls"
+
+    def test_stream_pure_tool_call_emits_tool_calls(self, sync_client, openai_headers, monkeypatch):
+        """Streaming pure tool call (no text) should end with finish_reason=tool_calls."""
+        monkeypatch.setattr(_settings, "ACP_SURFACE_TOOL_CALLS", True)
+        sync_client.app.state.shim_service = _ShimService(_PureToolCallACP())
+        payload = {**self._CHAT, "stream": True}
+        resp = sync_client.post("/v1/chat/completions", json=payload, headers=openai_headers)
+        assert '"finish_reason": "tool_calls"' in resp.text
+
+    def test_non_stream_tool_call_with_content_emits_stop(self, sync_client, openai_headers, monkeypatch):
+        """A turn with tool calls AND content should use finish_reason=stop (not tool_calls)."""
+        monkeypatch.setattr(_settings, "ACP_SURFACE_TOOL_CALLS", True)
+        sync_client.app.state.shim_service = _ShimService(_ToolEmittingACP())
+        resp = sync_client.post("/v1/chat/completions", json=self._CHAT, headers=openai_headers)
+        choice = resp.json()["choices"][0]
+        assert choice["finish_reason"] == "stop", (
+            "finish_reason must be stop when content is present alongside tool_calls "
+            "(kiro-cli already ran the tool and returned the answer)"
+        )
+
+    def test_stream_tool_call_with_content_emits_stop(self, sync_client, openai_headers, monkeypatch):
+        """Streaming a turn with tools + content must end with finish_reason=stop."""
+        monkeypatch.setattr(_settings, "ACP_SURFACE_TOOL_CALLS", True)
+        sync_client.app.state.shim_service = _ShimService(_ToolEmittingACP())
+        payload = {**self._CHAT, "stream": True}
+        resp = sync_client.post("/v1/chat/completions", json=payload, headers=openai_headers)
+        assert '"finish_reason": "stop"' in resp.text
+        assert '"finish_reason": "tool_calls"' not in resp.text
+
+    def test_tool_name_sanitization_replaces_invalid_chars(self, sync_client, openai_headers, monkeypatch):
+        """kiro-cli tool names with spaces/colons/slashes are sanitized to valid identifiers."""
+        monkeypatch.setattr(_settings, "ACP_SURFACE_TOOL_CALLS", True)
+        sync_client.app.state.shim_service = _ShimService(_DirtyNameToolACP())
+        resp = sync_client.post("/v1/chat/completions", json=self._CHAT, headers=openai_headers)
+        body = resp.json()
+        tcs = body["choices"][0]["message"]["tool_calls"]
+        names = [tc["function"]["name"] for tc in tcs]
+        assert all(" " not in n for n in names), f"Tool names still contain spaces: {names}"
+        assert all(":" not in n for n in names), f"Tool names still contain colons: {names}"
+        assert all("/" not in n for n in names), f"Tool names still contain slashes: {names}"
+        # Empty name falls back to kiro_tool.
+        assert "kiro_tool" in names
+
+    def test_stream_tool_name_sanitization(self, sync_client, openai_headers, monkeypatch):
+        """Streaming tool names must also be sanitized."""
+        monkeypatch.setattr(_settings, "ACP_SURFACE_TOOL_CALLS", True)
+        sync_client.app.state.shim_service = _ShimService(_DirtyNameToolACP())
+        payload = {**self._CHAT, "stream": True}
+        resp = sync_client.post("/v1/chat/completions", json=payload, headers=openai_headers)
+        assert "Running: ls" not in resp.text
+        assert "Running__ls" in resp.text or "Running_ls" in resp.text
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Three tool-call fixes found and verified via live kiro-cli 2.12.0 ACP probing.

## 1. Harness hang on built-in tool activity (closes #65)
- `finish_reason=tool_calls` / `stop_reason=tool_use` was returned even when kiro-cli already ran its tool and produced a text answer, deadlocking Claude Code / OpenCode.
- Now emitted only when tool calls are present **and** no text content was produced; otherwise `stop`/`end_turn`.
- kiro-cli tool titles (`Running: ls -la /tmp`) sanitized to valid function names via `_sanitize_tool_name()`.
- Fixed across OpenAI + Anthropic × stream + non-stream + Responses API stream.

## 2. Tool output dropped from activity view (closes #66)
Shell/`execute` and `web_search` report their output as `Json` shapes that `_summarize_json_output` didn't recognize, so the output was silently lost:
- **Shell / use_aws** (`kind='execute'`): `{exit_status, stdout, stderr}` → now extracts stdout/stderr + `[exit: N]` on failure. Handles both `exit status: N` and bare-number (`253`, from use_aws) forms.
- **web_search** (`kind='search'`): `{results:[{title,url,snippet}]}` → now renders a short `N result(s):` title/URL list.

Coverage confirmed across **all** kiro-cli built-in tools:

| Tool | kind | shape | status |
|------|------|-------|--------|
| Shell | execute | Json {exit_status,stdout,stderr} | fixed |
| use_aws | execute | Json (bare exit code) | covered by execute fix |
| Grep | search | Json {numMatches} | already worked |
| Glob | search | Json {filePaths} | already worked |
| web_search | search | Json {results:[...]} | fixed |
| web_fetch | read | Text | label-only (by design) |
| File read | read | Text | label-only (by design) |
| File create/edit | edit | content:[{type:diff}] | diff at call time |

## Testing
- Full suite: **690 passed, 1 skipped** (23 new regression tests).
- Every fix verified before/after with live kiro-cli 2.12.0 probes.