### PR TITLE
fix(acp): surface web_search results in activity view

### DIFF
--- a/kiro/acp_client.py
+++ b/kiro/acp_client.py
@@ -190,12 +190,18 @@ def _summarize_json_output(payload: Any) -> str:
 
     * **grep** — ``{"numMatches", "numFiles", …}`` → a one-line match summary.
     * **glob** — ``{"filePaths"|"totalFiles", …}`` → a one-line file-count summary.
+    * **web_search** — ``{"results": [{"title", "url", "snippet"}, …]}`` → a short
+      list of the top result titles/URLs. Verified against a live kiro-cli 2.12.0
+      probe: web_search runs as a ``search``-kind tool whose result is this
+      ``Json`` shape — without this branch the results are dropped from the
+      activity view (inconsistent with grep/glob, which are summarised).
     * **execute (shell)** — ``{"exit_status", "stdout", "stderr"}`` → the command's
       stdout/stderr text, with a ``[exit: …]`` marker appended when the command
       failed (non-zero exit) so a failing command is visible even with no output.
-      Verified against a live kiro-cli 2.12.0 probe: shell output arrives as this
-      ``Json`` shape, **not** as a ``Text`` item — so without this branch the
-      output (and any failure) is silently dropped from the activity view.
+      Verified against a live kiro-cli 2.12.0 probe: shell output (and ``use_aws``,
+      which also runs as an ``execute``-kind tool) arrives as this ``Json`` shape,
+      **not** as a ``Text`` item — so without this branch the output (and any
+      failure) is silently dropped from the activity view.
 
     Args:
         payload: The ``Json`` value from a tool ``rawOutput`` item.
@@ -221,6 +227,26 @@ def _summarize_json_output(payload: Any) -> str:
         if count is None:
             count = len(payload.get("filePaths") or [])
         return f"{count} file(s) found"
+    # web_search: {"results": [{"title", "url", "snippet"}, ...]}. Checked after
+    # grep (whose result items are file/matches, not title/url, and which is
+    # caught by numMatches above) so the two never collide.
+    results = payload.get("results")
+    if (
+        isinstance(results, list) and results
+        and isinstance(results[0], dict)
+        and ("title" in results[0] or "url" in results[0])
+    ):
+        lines = [f"{len(results)} result(s):"]
+        for entry in results[:5]:
+            if not isinstance(entry, dict):
+                continue
+            title = str(entry.get("title") or "").strip()
+            url = str(entry.get("url") or "").strip()
+            if title and url:
+                lines.append(f"- {title} ({url})")
+            elif title or url:
+                lines.append(f"- {title or url}")
+        return "\n".join(lines)
     # execute (shell): {"exit_status": "exit status: N", "stdout": ..., "stderr": ...}
     if "exit_status" in payload or "stdout" in payload or "stderr" in payload:
         stdout = str(payload.get("stdout") or "").rstrip()

--- a/tests/unit/test_acp_client.py
+++ b/tests/unit/test_acp_client.py
@@ -1710,6 +1710,51 @@ class TestStructuredToolRendering:
         assert "command not found" in rendered
         assert "[exit: 127]" in rendered
 
+    def test_use_aws_bare_exit_code_marker(self):
+        """use_aws runs as an execute-kind tool; its exit_status is a bare number
+        (e.g. "253"), not "exit status: N". The failure marker must still appear."""
+        out = ACPClient._extract_tool_output({"items": [{"Json": {
+            "exit_status": "253", "stdout": "",
+            "stderr": "\naws: [ERROR]: An error occurred (NoCredentials)...\n"}}]})
+        assert "NoCredentials" in out
+        assert "[exit: 253]" in out
+
+    # --- web_search tool output ({"results": [{"title","url","snippet"}]}) ---
+
+    def test_web_search_results_summarized(self):
+        """web_search results are summarised as a short title/URL list."""
+        out = ACPClient._extract_tool_output({"items": [{"Json": {"results": [
+            {"title": "IANA Reserved Domains", "url": "https://res-dom.iana.org/",
+             "snippet": "example.com and example.org ..."},
+            {"title": "Example Domain", "url": "https://example.com/", "snippet": "..."},
+        ]}}]})
+        assert "2 result(s)" in out
+        assert "IANA Reserved Domains" in out
+        assert "https://res-dom.iana.org/" in out
+
+    def test_web_search_rendered_in_search_branch(self):
+        """render_tool_activity surfaces web_search results inline under the search kind."""
+        out = ACPClient._extract_tool_output({"items": [{"Json": {"results": [
+            {"title": "T1", "url": "https://a.example/"}]}}]})
+        rendered = render_tool_activity(
+            {"type": "tool_call_update", "kind": "search", "output": out})
+        assert "T1" in rendered
+        assert "↳" in rendered
+
+    def test_web_search_title_only(self):
+        """A result with only a title (no url) still renders."""
+        out = ACPClient._extract_tool_output(
+            {"items": [{"Json": {"results": [{"title": "Only Title"}]}}]})
+        assert "Only Title" in out
+
+    def test_grep_results_not_mistaken_for_web_search(self):
+        """A grep result (has numMatches; result items are file/matches) is still
+        summarised as grep, never as web_search, despite carrying a `results` key."""
+        out = ACPClient._extract_tool_output({"items": [{"Json": {
+            "numMatches": 3, "numFiles": 2,
+            "results": [{"file": "x", "matches": ["a"]}]}}]})
+        assert out == "3 match(es) in 2 file(s)"
+
 
 # ---------------------------------------------------------------------------
 # Multi-turn prompt serialization (issue #43): the stateless gateway carries


### PR DESCRIPTION
Follow-up to #67 — this commit was pushed to the previous branch after #67 was already merged, so it did not land on main. This PR gets it in.

## Fix (closes #68)
web_search (`kind='search'`) reports `Json {"results":[{title,url,snippet}]}`, a shape `_summarize_json_output` didn't recognise → results were dropped from the activity view. Now renders a short `N result(s):` title/URL list, consistent with grep/glob.

Guarded so grep's `results` key never collides (grep is caught earlier by `numMatches`; its items are file/matches, not title/url).

Also confirmed via live probe (documented in the commit):
- **use_aws** (`kind='execute'`) — same Json shape as shell, bare numeric exit code; already covered by the execute fix (regex handles both forms). Regression test added.
- **web_fetch** (`kind='read'`, Text) — label-only, consistent with the file-read policy.

## Testing
- Full suite: **690 passed, 1 skipped** (5 new regression tests for web_search + use_aws).
- Verified live: reasoning channel now shows `↳ 10 result(s): - IANA-managed Reserved Domains (https://res-dom.iana.org/) ...`.