### PR TITLE
fix(anthropic): handle embedded system/developer messages in messages…

### DIFF
--- a/kiro/routes_anthropic_shim.py
+++ b/kiro/routes_anthropic_shim.py
@@ -292,6 +292,20 @@ def _anthropic_messages_to_acp(
             result.append(PromptMessage(role="system", content=system_text))
 
     for m in messages:
+        # Claude Code 2.1.215+ can embed ``role: "system"`` messages inside the
+        # messages array (runtime reminders with cache_control). These must be
+        # preserved as system/developer-role instructions, not misclassified as
+        # assistant. ``developer`` is an OpenAI convention but may appear from
+        # cross-API clients; treat it the same as system (issue #190).
+        if m.role in ("system", "developer"):
+            embedded_text = _system_to_text(
+                m.content if isinstance(m.content, (list, str)) else [m.content]
+            )
+            if embedded_text:
+                acp_role = "system" if m.role == "system" else "developer"
+                result.append(PromptMessage(role=acp_role, content=embedded_text))
+            continue
+
         role = "user" if m.role == "user" else "assistant"
 
         if isinstance(m.content, str):
@@ -827,17 +841,34 @@ async def count_message_tokens(body: AnthropicCountTokensRequest):
         ``{"input_tokens": int}`` — a local tokenizer estimate (not an exact
         server-side count, which kiro-cli/ACP does not expose).
     """
-    messages = [
-        {"role": m.role, "content": m.content}
-        for m in body.messages
-    ]
+    # Claude Code 2.1.215+ may embed role:"system" messages in the array.
+    # Extract them and merge into the system field for accurate counting.
+    conversation_messages: list[dict] = []
+    embedded_system_parts: list[str] = []
+    for m in body.messages:
+        if m.role == "system":
+            text = _system_to_text(
+                m.content if isinstance(m.content, (list, str)) else [m.content]
+            )
+            if text:
+                embedded_system_parts.append(text)
+        else:
+            conversation_messages.append({"role": m.role, "content": m.content})
+
+    # Merge embedded system content with the top-level system field.
+    merged_system: str | list | None = body.system
+    if embedded_system_parts:
+        base_text = _system_to_text(body.system) or ""
+        all_system = "\n".join(filter(None, [base_text] + embedded_system_parts))
+        merged_system = all_system or None
+
     tools = [
         {"name": t.name, "description": t.description or "", "input_schema": t.input_schema}
         for t in (body.tools or [])
     ]
     input_tokens = estimate_request_tokens(
-        messages=messages,
+        messages=conversation_messages,
         tools=tools or None,
-        system=body.system,
+        system=merged_system,
     )
     return {"input_tokens": input_tokens}

--- a/tests/unit/test_routes_anthropic_shim.py
+++ b/tests/unit/test_routes_anthropic_shim.py
@@ -185,6 +185,35 @@ def test_anthropic_count_tokens_content_blocks(sync_client, anthropic_headers):
     assert response.json()["input_tokens"] > 0
 
 
+def test_anthropic_count_tokens_embedded_system_messages(sync_client, anthropic_headers):
+    """Embedded role:'system' messages in messages[] are counted as system tokens."""
+    # Baseline: only user message, no system
+    base_payload = {
+        "model": "claude-sonnet-4.6",
+        "messages": [{"role": "user", "content": "Hi"}],
+    }
+    base = sync_client.post(
+        "/v1/messages/count_tokens", json=base_payload, headers=anthropic_headers
+    ).json()["input_tokens"]
+
+    # With embedded system message — should increase tokens
+    embedded_payload = {
+        "model": "claude-sonnet-4.6",
+        "messages": [
+            {"role": "user", "content": "Hi"},
+            {"role": "system", "content": [
+                {"type": "text", "text": "You are a meticulous and very verbose assistant that always explains in detail.",
+                 "cache_control": {"type": "ephemeral"}},
+            ]},
+        ],
+    }
+    embedded = sync_client.post(
+        "/v1/messages/count_tokens", json=embedded_payload, headers=anthropic_headers
+    )
+    assert embedded.status_code == 200
+    assert embedded.json()["input_tokens"] > base
+
+
 # ---------------------------------------------------------------------------
 # Base-URL path mounts — the Anthropic shim must answer on every common
 # base-URL convention (regression: clients hitting /messages and
@@ -394,6 +423,55 @@ class TestAnthropicMessagesToACP:
         ], system="sys")
         assert [m.role for m in msgs] == ["system", "user", "assistant", "user"]
         assert [m.content for m in msgs] == ["sys", "q1", "a1", "q2"]
+
+    # -- Embedded system messages (Claude Code 2.1.215+, issue #255) ---------
+
+    def test_embedded_system_message_gets_system_role(self):
+        """A role:'system' message in messages[] should become a system PromptMessage."""
+        from kiro.routes_anthropic_shim import _anthropic_messages_to_acp, AnthropicMessage
+        msgs = _anthropic_messages_to_acp([
+            AnthropicMessage(role="user", content="hello"),
+            AnthropicMessage(role="system", content=[
+                {"type": "text", "text": "Be careful", "cache_control": {"type": "ephemeral"}},
+            ]),
+            AnthropicMessage(role="user", content="what is 2+2?"),
+        ], system=None)
+        assert [m.role for m in msgs] == ["user", "system", "user"]
+        assert msgs[1].content == "Be careful"
+
+    def test_embedded_system_message_coexists_with_top_level_system(self):
+        """Both top-level system and embedded system messages are preserved."""
+        from kiro.routes_anthropic_shim import _anthropic_messages_to_acp, AnthropicMessage
+        msgs = _anthropic_messages_to_acp([
+            AnthropicMessage(role="user", content="hi"),
+            AnthropicMessage(role="system", content=[
+                {"type": "text", "text": "runtime reminder"},
+            ]),
+        ], system="top-level system")
+        assert msgs[0].role == "system"
+        assert msgs[0].content == "top-level system"
+        assert msgs[2].role == "system"
+        assert msgs[2].content == "runtime reminder"
+
+    def test_embedded_system_message_string_content(self):
+        """An embedded system message with plain string content is handled."""
+        from kiro.routes_anthropic_shim import _anthropic_messages_to_acp, AnthropicMessage
+        msgs = _anthropic_messages_to_acp([
+            AnthropicMessage(role="system", content="be concise"),
+            AnthropicMessage(role="user", content="hi"),
+        ], system=None)
+        assert msgs[0].role == "system"
+        assert msgs[0].content == "be concise"
+        assert msgs[1].role == "user"
+
+    def test_embedded_system_message_not_misclassified_as_assistant(self):
+        """Regression: system role must NOT fall through to the else='assistant' branch."""
+        from kiro.routes_anthropic_shim import _anthropic_messages_to_acp, AnthropicMessage
+        msgs = _anthropic_messages_to_acp([
+            AnthropicMessage(role="system", content="instruction"),
+        ], system=None)
+        assert msgs[0].role == "system"
+        assert msgs[0].role != "assistant"
 
 
 


### PR DESCRIPTION
… array

Claude Code 2.1.x+ sends role:'system' (and potentially 'developer') messages inside the messages[] array for runtime context reminders. Previously these were silently misclassified as 'assistant' role. Now they are correctly preserved as system/developer PromptMessages, maintaining instruction semantics.

Also fixes count_tokens endpoint to extract embedded system messages and merge them into the system field for accurate token counting.