### PR TITLE
feat: support kiro-cli v3 agent engine + embedded documents

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -57,10 +57,16 @@ KIRO_ACP_MODE=
 # Flags passed to `kiro-cli acp` at launch. All optional; leave blank to keep
 # the default behaviour. The engine is always pinned explicitly (default v2).
 # --agent-engine: v1 | v2 | v3. Pinned to v2 (kiro-cli's current default) so a
-# future change to the default engine can't silently alter behaviour. v3 needs
-# host-mediated auth the gateway does not implement (generation fails) — see
-# the v3 auth issue; keep v2.
+# future change to the default engine can't silently alter behaviour. v3 is
+# supported (see COMPLIANCE.md) but requires the auth bridge below; keep v2
+# unless you specifically want v3.
 KIRO_ACP_ENGINE=v2
+# v3 ONLY: the v3 agent server is launched with a hardcoded --auth=acp-callback
+# and asks the gateway for an access token. true (default) = relay a short-lived
+# token obtained from kiro-cli itself; the refresh token is never read and
+# nothing is stored. false = decline it, so v3 fails closed with a 401 rather
+# than the gateway handling a credential. Inert on v1/v2.
+ACP_AUTH_BRIDGE=true
 # --agent: name of a (custom) agent config to use for the first session.
 KIRO_ACP_AGENT=
 # --model: model id to select when starting the first session. NOTE: distinct

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -197,6 +197,46 @@ v1/v2 behaviour is unchanged and every v3 branch is gated on `self._engine`.
 - **Permission option ids differ** (`accept`/`always-accept`/`reject`/
   `always-reject`) but the `kind` values are standard, and `select_option_id`
   matches on `kind` first — so no change was needed.
+- **`ACP_TRUST_TOOLS` is honoured on v3, for every tool kiro-cli asks about.**
+  Enforcement hangs off `session/request_permission`, which is engine-agnostic:
+  verified live through the gateway's own `ACPClient` on v3, `trust_tools=False`
+  produced "The command didn't run — you rejected the tool call" while
+  `trust_tools=True` executed the same command. What differs is *which* tools v3
+  asks about: it decides that with its own `permissions.yaml` policy engine
+  (`deny > ask > allow`, no precedence between scopes), and a tool that policy
+  already **allows** runs without ever sending the request — so the gateway is
+  never consulted and cannot refuse it. A user-scope `capability: all -> allow`
+  therefore pre-approves everything. The gateway cannot close that from here (v3
+  rejects the trust flags, and ACP exposes no method to push policy), so
+  `_warn_restrictive_posture_on_v3` logs a warning instead of letting an operator
+  believe an answer-only deployment is airtight; the only hard fix is a `deny`
+  rule in kiro-cli's own policy, which beats every `allow`. First-party
+  `kirodotdev/KiroCrew` documents the same constraint ("kiro-cli only sends
+  `session/request_permission` for tools it must ask about") and solves it the
+  same way — by never pre-approving what policy would deny.
+- **v3 rejects every session-scope spawn flag.** `--agent`, `--model`,
+  `--effort`, `--trust-all-tools` and `--trust-tools` each make `kiro-cli acp`
+  exit immediately with `error: the following arguments are not supported with
+  --agent-engine=v3`, *before* any JSON-RPC — it does not ignore them. Passing an
+  operator's `KIRO_ACP_AGENT`/`KIRO_ACP_MODEL`/`KIRO_ACP_EFFORT` through would
+  therefore break every request, so `_build_argv` drops them with a warning via
+  `ENGINE_UNSUPPORTED_SPAWN_FLAGS` (v1/v2 argv is byte-identical to before) and
+  the model is still applied per session by `set_model`. Only `--auth-method`
+  and `-v` are additionally accepted on v3.
+- **v3 reports no `agentInfo`.** `initialize` omits the key entirely, so
+  `initialize` normalises a missing/`null` value and falls back to a best-effort
+  `kiro-cli --version` (`_probe_cli_version`, exposed as `agent_name` /
+  `agent_version`). Informational only — it can never fail startup.
+- **v3 ignores EOF on stdin.** Closing stdin does not stop the process (v1/v2
+  exit promptly), so `stop()` escalates stdin-close → `SIGTERM` → `SIGKILL` with
+  a bounded wait per stage and awaits each one so the process is reaped.
+  `ENGINES_IGNORING_STDIN_EOF` skips the stdin stage for v3, which took gateway
+  shutdown from ~5s to ~0s.
+- **Answer agent requests off the read loop.** The auth callback shells out, so
+  `_dispatch` schedules handlers as tasks and keeps a **strong reference** to
+  them (`_agent_request_tasks`) — asyncio only weakly references scheduled tasks,
+  so without it an in-flight handler can be garbage-collected mid-await and the
+  agent waits forever for a reply that is never written.
 - **Decline everything else.** v3 offers `_kiro/fs/read|write|delete`, hooks,
   checkpoints, `_kiro/openExternalUrl`, session list/fork/history. The gateway
   answers **only** the auth callback and `session/request_permission`; keep it
@@ -204,6 +244,56 @@ v1/v2 behaviour is unchanged and every v3 branch is gated on `self._engine`.
 - **v3 auto-loads kiro-cli's own MCP servers** regardless of `mcpServers: []`,
   and kiro-cli sets `KIRO_CONTENT_COLLECTION_ENABLED=true` / telemetry env on the
   agent server. Both are kiro-cli's posture, not the gateway's.
+
+#### Before switching the default to v3
+
+v3 works end-to-end today (`KIRO_ACP_ENGINE=v3` completes `initialize` /
+`session/new` / `session/prompt` and returns generated text), but **`v2` remains
+the default** until the items below are settled. Each was verified against a live
+kiro-cli 2.19.x / KAS 0.48.0 probe. Treat this as the checklist for flipping the
+default — not as a list of things that break a v3 session.
+
+**Open design decisions (not yet implemented — these change the PR's premise):**
+
+1. **`--auth-method cli` may make `ACP_AUTH_BRIDGE` unnecessary.** `kiro-cli acp`
+   accepts `--auth-method cli` on v3 — "Resolve access tokens for the v3 engine
+   from the Kiro CLI credential store", i.e. authentication stays *inside*
+   kiro-cli instead of the agent server calling back to the gateway for a token.
+   That is strictly closer to the compliance model (principle 1: the gateway
+   never handles credentials) and would remove the whole
+   `_kiro/auth/getAccessToken` path, `kiro/kiro_auth.py`, and the token-shaped
+   failure modes. It is **not** wired up: the gateway still spawns v3 with the
+   hardcoded `--auth=acp-callback` posture and answers the callback. Decide
+   between the two before v3 becomes the default, and prefer `--auth-method cli`
+   unless a live probe shows it cannot refresh mid-session.
+2. **v3's informational pushes are declined.** `_kiro/governance/state` and
+   `_kiro/tools/didChange` are agent→client **requests** the gateway answers with
+   `-32601`. Harmless today (the session proceeds), but they are precisely where
+   kiro-cli reports its **feature ceiling** and **tool tags** — e.g.
+   `{isEnterprise, features: {mcpEnabled, webToolsEnabled, autonomousAgents, …},
+   disabledReason}` and `tags: [{source: builtin, tag: read|write|shell|web}]`.
+   Consuming them would let the gateway know which capabilities an account is
+   actually served *before* a turn fails, rather than discovering it from an
+   error. Declining them is a deliberate least-privilege choice, so this is a
+   feature decision, not a bug.
+
+**Behavioural differences an operator must know about:**
+
+3. **Existing `KIRO_ACP_*` spawn config is silently inert on v3.**
+   `KIRO_ACP_AGENT`, `KIRO_ACP_MODEL` and `KIRO_ACP_EFFORT` are dropped (v3
+   rejects the flags outright — see above). Before this fix they made **every**
+   v3 request fail; now they are dropped with a warning. An operator relying on
+   `KIRO_ACP_AGENT` to select a custom agent has **no v3 equivalent** through the
+   gateway, and `KIRO_ACP_MODE` uses different mode ids per engine.
+4. **`ACP_TRUST_TOOLS=false` is not an airtight guarantee on v3.** It is honoured
+   for every tool kiro-cli asks about, but a tool pre-approved by kiro-cli's own
+   `permissions.yaml` never reaches the gateway. A hard answer-only posture needs
+   a `deny` rule in that file (deny beats allow in every scope) — or `v2`. The
+   gateway warns; it cannot enforce.
+5. **`KIRO_ACP_ENGINE=v3` requires a per-account model check.** Sending a model
+   the account is not served hangs the turn ~4 min and then reports a misleading
+   "Access denied" on v3 (`504` on v2). `_is_served` guards both engines; don't
+   set `MODEL_VALIDATION=off` on v3 without knowing the served catalogue.
 
 ### Tool permission policy (`kiro/tool_permissions.py`)
 
@@ -667,7 +757,7 @@ take precedence over `.env`).
 | `MODEL_VALIDATION` | `warn` | How a requested model absent from the live catalogue is handled: `warn` (log + fall back), `strict` (404 native error), `off` (forward silently). Skipped until the catalogue is known (issue #42). |
 | `MODEL_ALIASES` | `` (none) | Comma-separated `alias=target` pairs rewriting a requested model id to a real kiro-cli model before validation/`set_model` (e.g. `gpt-4o=claude-sonnet-4.6`). |
 | `ENFORCE_MAX_TOKENS` | `false` | When `true`, the gateway caps output at `max_tokens` (`finish_reason=length`). `stop` sequences are always enforced when sent. kiro-cli honors neither over ACP (issue #32). |
-| `ACP_TRUST_TOOLS` | `true` | Auto-approve (`true`) or reject (`false`) tool permission requests |
+| `ACP_TRUST_TOOLS` | `true` | Auto-approve (`true`) or reject (`false`) tool permission requests. Honoured on every engine, but on `v3` only for tools kiro-cli actually asks about — its `permissions.yaml` can pre-approve a tool and skip the request entirely (see the v3 section). |
 | `ACP_SURFACE_TOOL_CALLS` | `false` | How the shims present kiro-cli's built-in tool activity: `false` (default) = inline non-executable reasoning text (interleaved, needs `ACP_SURFACE_THINKING`); `true` = executable `tool_calls`/`tool_use`, name-mapped onto the caller's declared tools by `kind` (`map_kiro_tool_call`). ACP-native route always emits a structured `acp_tool_call`. |
 | `ACP_SURFACE_THINKING` | `true` | Surface kiro-cli reasoning in each API's native shape (OpenAI `reasoning_content` / Responses reasoning items; Anthropic `thinking` blocks). Additive — final answer unchanged. `false` emits only the answer. |
 | `KIRO_MCP_SERVERS` | `` (none) | Inline JSON of MCP servers registered on every `session/new` (ACP `mcpServers` array or `mcp.json` object form). kiro-cli runs them itself (`mcpCapabilities.http`). The only external-tool channel over ACP. |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -107,6 +107,7 @@ kiro-gateway/
 │   ├── routes_anthropic_shim.py# /v1/messages, /v1/models
 │   ├── routes_acp.py           # /acp/chat, /acp/chat/stream
 │   ├── harness_mcp.py          # Discover the harness's own MCP servers (issue #75)
+│   ├── kiro_auth.py            # v3 auth callback: relay a kiro-cli access token (issue #52)
 │   ├── config.py               # Env-driven settings (settings object + module constants)
 │   ├── compliance.py           # Single-account enforcement at startup
 │   └── capability_executor.py  # Stub capability dispatch (retained; not in the live path)
@@ -155,6 +156,54 @@ matter — a malformed `initialize` makes the agent exit immediately.
 client-side `fs`/`terminal` capabilities, so it only answers permission
 requests (auto-approve `allow_once` when `ACP_TRUST_TOOLS=true`, else
 `reject_once`) — refined by an optional rule policy, below.
+
+### The v3 agent engine (issue #52)
+
+`KIRO_ACP_ENGINE=v3` is supported but is a **different protocol surface**.
+Everything below was verified against a live kiro-cli 2.18.0 / KAS 0.38.7 probe;
+v1/v2 behaviour is unchanged and every v3 branch is gated on `self._engine`.
+
+- **`kiro-cli acp --agent-engine v3` does not run the agent.** It spawns the Kiro
+  Agent Server with a hardcoded `--auth=acp-callback`, so the server asks the
+  *client* for an access token via `_kiro/auth/getAccessToken` (connection-level:
+  **no `sessionId`**). Declining it still allows `initialize` and `session/new`,
+  but every `session/prompt` fails `-32000 Auth refresh callback failed`.
+  `kiro/kiro_auth.py` answers it by shelling out to `kiro-cli chat _
+  get-kas-token`; only the covenant keys are forwarded, nothing is cached, and
+  failure messages are **fixed strings** (subprocess output could be a live
+  token). Same mechanism as first-party `kirodotdev/KiroCrew`.
+- **A JSON-RPC response must carry exactly one of `result`/`error`.** The old
+  `_respond_error` emitted `result: null` alongside `error`; v3 reads `result`
+  first and dies with `-32603 Internal error` / `Cannot read properties of null`.
+  `_respond` / `_respond_error` now exclude the unused member — don't reintroduce it.
+- **There is no `session/set_model`.** The model is a *session config option*:
+  `session/set_config_option {sessionId, configId: "model", value}`. `set_model`
+  branches on the engine.
+- **`session/new` returns no `models` block.** The catalogue arrives as
+  `configOptions` (`{"id": "model", "currentValue", "options": [{"value", "name"}]}`),
+  parsed by `_capture_config_option_catalogue`; `_normalise_catalogue` accepts
+  `modelId` (v2) / `value` (v3) / `id` (modes). A `config_option_update`
+  notification pushes a **replacement** array mid-session.
+- **Never send an unserved model/mode** (`_is_served`). The old assumption that
+  kiro-cli ignores an unknown id is wrong: an id the account isn't served (e.g.
+  the widely hardcoded `claude-sonnet-4.6`) hangs the turn ~4 min and then fails
+  — `504` on v2, a misleading "Access denied" on v3. The guard applies to **both**
+  engines (it fixed a pre-existing v2 bug); `MODEL_VALIDATION=off` forces the id.
+- **Mode ids differ:** v3 uses `vibe`/`spec`/`plan`/`autonomous`/…, v2 uses
+  `kiro_default`/`code`/`kiro_planner`/`kiro_guide`. `KIRO_ACP_MODE` is
+  engine-specific.
+- **Tool output shape differs:** v3 `rawOutput` is `{"output": "…"}`, v2 is
+  `{"items": [{"Text": …}]}`. Both handled in `_extract_tool_output`.
+- **Permission option ids differ** (`accept`/`always-accept`/`reject`/
+  `always-reject`) but the `kind` values are standard, and `select_option_id`
+  matches on `kind` first — so no change was needed.
+- **Decline everything else.** v3 offers `_kiro/fs/read|write|delete`, hooks,
+  checkpoints, `_kiro/openExternalUrl`, session list/fork/history. The gateway
+  answers **only** the auth callback and `session/request_permission`; keep it
+  that way, and don't advertise capabilities (e.g. `elicitation`) we don't serve.
+- **v3 auto-loads kiro-cli's own MCP servers** regardless of `mcpServers: []`,
+  and kiro-cli sets `KIRO_CONTENT_COLLECTION_ENABLED=true` / telemetry env on the
+  agent server. Both are kiro-cli's posture, not the gateway's.
 
 ### Tool permission policy (`kiro/tool_permissions.py`)
 
@@ -381,6 +430,7 @@ modes — never a bare `502 {"detail": ...}`.
 | rate limit / throttle / quota / `429` | `429` | `rate_limit_error` | `rate_limit_error` |
 | overloaded / unavailable / capacity | `503` | `server_error` | `overloaded_error` |
 | timeout / deadline | `504` | `server_error` | `api_error` |
+| kiro-cli not authenticated (v3 bridge) | `401` | `authentication_error` | `authentication_error` |
 | default | `502` | `server_error` | `api_error` |
 
 - `classify_exception(exc)` for non-streaming (reads `ACPError.code/.data`);
@@ -609,7 +659,8 @@ take precedence over `.env`).
 | `MCP_DISCOVERY` | `all` | Scope for discovering the **harness's own** MCP servers (`kiro.harness_mcp`) and forwarding them on `session/new` — on by default, no config needed. `all` = user + workspace configs; `user` = user-level only (hardening for untrusted repos); `off` = disable. Not in `.env.example` by design. |
 | `ACP_WORKSPACE_DIR` | process cwd | **Fallback** session `cwd`. The cwd is resolved per request (`X-Kiro-Workspace` header → `filesystem_roots` → the prompt `<env>` `Working directory:` line, parsed by `kiro.workspace`) so kiro-cli anchors in the harness's directory by default; this is used only when none is present. cwd is an anchor, not a jail (verified live) — tools still reach absolute paths elsewhere. |
 | `KIRO_ACP_MODE` | `` (kiro-cli default) | Agent persona selected per session via `session/set_mode` (`kiro_default`, `code`, `kiro_planner`, `kiro_guide`). Unknown value accepted silently (keeps default). Distinct from `KIRO_ACP_MODEL`. |
-| `KIRO_ACP_ENGINE` | `v2` | `--agent-engine` (`v1`/`v2`/`v3`), pinned explicitly so a future default-engine flip can't change behaviour. `v3` needs host-mediated auth the gateway lacks (issue #52) — generation fails; keep `v2`. Invalid value falls back to `v2`. |
+| `KIRO_ACP_ENGINE` | `v2` | `--agent-engine` (`v1`/`v2`/`v3`), pinned explicitly so a future default-engine flip can't change behaviour. `v3` is supported (issue #52) via the auth bridge below. Invalid value falls back to `v2`. |
+| `ACP_AUTH_BRIDGE` | `true` | **v3 only.** Answer the agent server's `_kiro/auth/getAccessToken` by relaying a short-lived token from `kiro-cli chat _ get-kas-token` (`kiro/kiro_auth.py`). Inert on v1/v2 (callback never sent). `false` = decline it, so v3 fails closed with `401`. See COMPLIANCE.md. |
 | `KIRO_ACP_AGENT` | `` (none) | `--agent`: (custom) agent config for the first session (spawn flag). |
 | `KIRO_ACP_MODEL` | `` (none) | `--model`: initial session model at spawn. Distinct from `KIRO_ACP_MODE`; a per-request model still overrides it. |
 | `KIRO_ACP_EFFORT` | `` (none) | `--effort`: initial thinking effort (`low`/`medium`/`high`/`xhigh`/`max`). |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -477,9 +477,10 @@ is still not honored by kiro-cli over ACP (issue #31).
 
 ## Multimodal input (`kiro/multimodal.py`, issue #33)
 
-Capability ground truth — **live kiro-cli 2.10.0 probe**
-(`initialize.agentCapabilities.promptCapabilities`): `{"image": true, "audio":
-false, "embeddedContext": false}`. So:
+Capability ground truth (`initialize.agentCapabilities.promptCapabilities`),
+**engine-dependent** — v1/v2 (live 2.10.0 probe): `{"image": true, "audio":
+false, "embeddedContext": false}`; v3 (live 2.18.0 probe): `{"image": true,
+"embeddedContext": true}`. So:
 
 - **Images forwarded.** `openai_part_to_blocks` / `anthropic_block_to_blocks`
   turn a base64 `image_url` / `input_image` / Anthropic `image` block into a
@@ -493,17 +494,33 @@ false, "embeddedContext": false}`. So:
   the live probe (a forwarded PNG changed the model's answer).
 - **Remote image URLs are NOT fetched** (no URL content-block capability;
   SSRF/egress risk) — surfaced as text.
-- **Documents reduced to text** (`embeddedContext: false` → binary rejected):
-  text-like mimes are decoded and injected; PDFs are extracted via `pypdf` (a
-  standard dependency — `_extract_pdf_text`, lazy import for graceful
-  degradation); a scanned/no-text PDF, other binary formats, and audio get an
-  explicit `[document: … omitted]` / `[audio omitted …]` placeholder — never a
-  silent drop.
+- **Documents: capability-gated (issue #58).** `ACPClient.supports_embedded_context`
+  (from the negotiated `promptCapabilities.embeddedContext`, **never** the engine
+  string) decides:
+  - **true (v3)** → the document is emitted as an ACP `resource` block
+    (`{"type":"resource","resource":{"uri","mimeType","text"|"blob"}}`, the
+    ACP/MCP `EmbeddedResource` shape) with an inline `[document]` marker, so the
+    agent parses the original bytes. Live 2.18.0 probe: the model read markers
+    from both a `text` resource and a base64 `blob` PDF, and a synthetic
+    `attachment:///` URI is accepted.
+  - **false (v1/v2)** → reduced to text as before: text-like mimes decoded and
+    injected; PDFs extracted via `pypdf` (`_extract_pdf_text`, lazy import for
+    graceful degradation); a scanned/no-text PDF, other binary formats, and audio
+    get an explicit `[document: … omitted]` / `[audio omitted …]` placeholder —
+    never a silent drop. The same probe showed v2 accepts a `resource` block
+    **without error but silently ignores it**, so this must stay capability-gated,
+    not try-and-fall-back.
+  Each normalised document block carries `data`/`text` **and** a ready-made
+  `fallback` string, so `_split_content(content, embed_documents)` just picks one.
+  Document-bearing content stays a **block list** on `PromptMessage.content`
+  (like images).
 
 When extending: keep both shims routed through `kiro.multimodal`, keep the image
-wire shape, and assert image forwarding + the document/audio placeholder path in
-tests (`tests/unit/test_multimodal.py`, plus the route + `_build_prompt_blocks`
-image tests). Don't fetch remote URLs server-side.
+wire shape, and assert both document branches + the audio placeholder path in
+tests (`tests/unit/test_multimodal.py`, plus `TestEmbeddedContextCapability` /
+`TestDocumentPromptRepresentation` and the route document tests). Don't fetch
+remote URLs server-side. If you touch the v1/v2 rendering, diff the prompt bytes
+against `main` — that path must stay byte-identical.
 
 ## Usage & token accounting (`kiro/tokenizer.py`)
 

--- a/COMPLIANCE.md
+++ b/COMPLIANCE.md
@@ -19,7 +19,7 @@ ACP-native clients    ──ACP────► /acp/*
 
 | Feature | `jwadow/kiro-gateway` (upstream) | `ankitcharolia/kiro-gateway` (this fork) |
 |---|---|---|
-| Auth / credential handling | Direct token/credential injection | ❌ Removed — kiro-cli manages auth |
+| Auth / credential handling | Direct token/credential injection | ❌ Removed — kiro-cli manages auth (v3 engine: one scoped, documented exception below) |
 | Kiro internal API calls | Direct HTTP to Kiro backend | ❌ Removed — ACP over kiro-cli only |
 | Multi-account failover | ✅ `ACCOUNT_SYSTEM=true` | ❌ Disabled — single account enforced |
 | ACP protocol support | ❌ Not present | ✅ Full ACP client (session/prompt, streaming) |
@@ -35,13 +35,83 @@ surfaces rather than any reverse-engineered API:
   only component that talks to Kiro.
 - ✅ **Agent Client Protocol (ACP)** — the gateway is a standards-based ACP
   client, the same protocol Kiro-compatible IDEs use.
-- ✅ **No credential handling** — all authentication lives inside `kiro-cli`
-  (`kiro-cli login`); the gateway never reads, stores, or forwards tokens.
+- ✅ **No credential handling on the default engine** — all authentication lives
+  inside `kiro-cli` (`kiro-cli login`); on `KIRO_ACP_ENGINE=v2` (the default)
+  the gateway never reads, stores or forwards a token. See the scoped v3
+  exception below.
 - ✅ **No private API calls** — the gateway never calls Kiro's internal HTTP
   endpoints and never pools accounts.
 
 The gateway is a **standards-based ACP client that wraps the official CLI**, not
 a credential extractor or internal-API interceptor.
+
+## Scoped exception: the v3 agent engine's auth callback
+
+`KIRO_ACP_ENGINE=v3` (opt-in; **not** the default) requires the gateway to
+handle one credential, so it is documented here explicitly rather than hidden.
+
+**Why it is unavoidable.** `kiro-cli acp --agent-engine v3` does not run the
+agent itself: it spawns the Kiro Agent Server (KAS) and launches it with
+`--auth=acp-callback`, which is hardcoded. Verified against a live kiro-cli
+2.18.0 process:
+
+```
+node --experimental-wasm-modules …/@kiro/agent/dist/server/acp-server.js \
+     --transport=stdio --auth=acp-callback
+```
+
+In that mode KAS keeps no credential of its own and asks its ACP *client* for an
+access token via `_kiro/auth/getAccessToken`. `kiro-cli acp` exposes no flag to
+select another mode, and KAS's alternatives (`--auth=user`, `--auth=machine`,
+`KIRO_API_KEY`) are unreachable through the CLI. A client that declines gets
+`initialize` and `session/new`, but every `session/prompt` fails with
+`-32000 Auth refresh callback failed`.
+
+**What the gateway does.** It relays a short-lived access token obtained **from
+kiro-cli itself** (`kiro-cli chat _ get-kas-token`, which resolves and refreshes
+the token inside the official binary) to kiro-cli's own agent server:
+
+| Property | Behaviour |
+|---|---|
+| OIDC refresh token | **Never read.** It stays in kiro-cli's own store. |
+| OIDC refresh flow | **Never performed by the gateway.** Delegated to the official binary. |
+| Token storage | **None.** Not cached, not written to disk (KAS caches internally — a live probe showed one callback per subprocess). |
+| Token logging | **Never.** Only expiry and presence flags are logged; failures raise fixed, token-free messages. |
+| Destination | kiro-cli's own agent server, over the existing stdio pipe. The gateway makes no HTTP call with it. |
+| Forwarded fields | Only the covenant keys (`accessToken`, `expiresAt`, `profileArn`, `authMethod`, `provider`) — never a raw passthrough. |
+
+Implementation: [`kiro/kiro_auth.py`](kiro/kiro_auth.py). Precedent: this is the
+same mechanism used by [`kirodotdev/KiroCrew`](https://github.com/kirodotdev/KiroCrew)
+(a first-party Kiro project) in `src/kiro_crew/acp/kas_auth.py`.
+
+**Operator control.** Set `ACP_AUTH_BRIDGE=false` to refuse the relay: the
+callback is then declined and v3 fails closed with a `401 authentication_error`
+instead of silently handling a credential. `KIRO_ACP_ENGINE=v2` (the default)
+avoids the question entirely.
+
+**Rejected alternatives.**
+- *Reading kiro-cli's credential store* (`data.sqlite3` → `auth_kv`): depends on
+  an undocumented on-disk schema and touches the row holding the refresh token,
+  for no benefit over the official command.
+- *Refreshing the token in the gateway*: would duplicate kiro-cli's auth logic
+  and risk desynchronising its store on refresh-token rotation, logging the user
+  out.
+- *Spawning KAS directly* (as KiroCrew does): would stop invoking the official
+  binary — the project's core claim — and couple the gateway to kiro-cli's
+  internal `kas/<version>-<hash>/` layout.
+
+**Unchanged on v3.** The gateway still advertises no client-side filesystem or
+terminal capabilities and declines every other agent callback v3 offers
+(`_kiro/fs/read|write|delete`, hooks, checkpoints, `_kiro/openExternalUrl`), so
+the least-privilege posture is identical to v2.
+
+**Inherited from kiro-cli, not chosen by the gateway.** When kiro-cli launches
+KAS it sets its own environment, including `KIRO_CONTENT_COLLECTION_ENABLED=true`
+and `KIRO_TELEMETRY_ENABLED=true`. That is kiro-cli's posture for any ACP client
+(the Kiro IDE included) and is the same whether you use the gateway or
+`kiro-cli chat` interactively; the gateway neither sets nor overrides it. v3 also
+auto-loads the MCP servers from kiro-cli's own configuration, independently of
+`KIRO_MCP_SERVERS` and `MCP_DISCOVERY`.
 
 > **Note on licensing.** The points above describe the project's design goals
 > and the maintainer's reading of Kiro's published integration paths; they are

--- a/README.md
+++ b/README.md
@@ -216,9 +216,17 @@ ACP_STDIO_MAX_BYTES=16777216     # Max bytes per ACP stdout line (16 MiB) — ra
 KIRO_ACP_MODE=
 # Flags passed to `kiro-cli acp` at launch (all optional). The engine is
 # pinned explicitly (default v2) so a future change to kiro-cli's default
-# engine can't silently alter behaviour. v3 needs host-mediated auth the
-# gateway does not implement (generation fails) — keep v2.
+# engine can't silently alter behaviour. v3 is supported but needs the auth
+# bridge below (see COMPLIANCE.md) — keep v2 unless you want v3's features.
 KIRO_ACP_ENGINE=v2               # v1 | v2 | v3
+# v3 ONLY: `kiro-cli acp --agent-engine v3` launches its agent server with a
+# hardcoded --auth=acp-callback, so the server asks the gateway for an access
+# token. true (default) = relay a short-lived token obtained from kiro-cli
+# itself (`kiro-cli chat _ get-kas-token`); the refresh token is never read and
+# nothing is stored. false = decline the callback, so v3 fails closed with a
+# 401 instead of the gateway handling a credential. Inert on v1/v2, where the
+# callback is never sent. See the "Scoped exception" section in COMPLIANCE.md.
+ACP_AUTH_BRIDGE=true
 KIRO_ACP_AGENT=                  # --agent: (custom) agent config for the first session
 KIRO_ACP_MODEL=                  # --model: initial session model (per-request model still wins)
 KIRO_ACP_EFFORT=                 # --effort: low | medium | high | xhigh | max
@@ -430,6 +438,7 @@ streaming and non-streaming paths.
 | Rate limit / throttle / quota / `429` | `429` | `rate_limit_error` | `rate_limit_error` |
 | Overloaded / unavailable / capacity | `503` | `server_error` | `overloaded_error` |
 | Timeout / deadline exceeded | `504` | `server_error` | `api_error` |
+| kiro-cli itself not authenticated (v3 auth bridge) | `401` | `authentication_error` | `authentication_error` |
 | Any other failure (default) | `502` | `server_error` | `api_error` |
 
 - **Non-streaming.** The response status code is the mapped code and the body

--- a/kiro/acp_client.py
+++ b/kiro/acp_client.py
@@ -62,6 +62,13 @@ from kiro.acp_models import (
     GatewayCapabilities,
 )
 from kiro.config import ACP_STDIO_MAX_BYTES, settings
+from kiro.kiro_auth import (
+    AUTH_CALLBACK_ERROR_CODE,
+    AUTH_CALLBACK_METHOD,
+    KiroAuthError,
+    KiroAuthResolver,
+    build_resolver,
+)
 from kiro.output_limits import StreamLimiter
 from kiro.tool_permissions import (
     DECISION_ALLOW,
@@ -404,6 +411,7 @@ class ACPClient:
         mcp_servers: Optional[list[dict]] = None,
         mcp_init_timeout: int = 30,
         permission_policy: Optional[ToolPermissionPolicy] = None,
+        auth_resolver: Optional[KiroAuthResolver] = None,
     ):
         self._command = command
         self._trust_tools = trust_tools
@@ -435,6 +443,16 @@ class ACPClient:
         self._initial_model = (initial_model or "").strip() or None
         self._effort = (effort or "").strip() or None
         self._engine = (engine or "v2").strip() or "v2"
+        # v3 agent engine only: the agent server is launched with a hardcoded
+        # --auth=acp-callback and asks the gateway for an access token
+        # (_kiro/auth/getAccessToken, issue #52). The resolver relays one from
+        # kiro-cli itself; it is None on v1/v2 (callback never sent) and when
+        # ACP_AUTH_BRIDGE is disabled, in which case the callback is declined.
+        if auth_resolver is None:
+            auth_resolver = build_resolver(
+                self._command, self._engine, settings.ACP_AUTH_BRIDGE
+            )
+        self._auth_resolver = auth_resolver
         self._extra_args = list(extra_args or [])
         # Default MCP servers registered on every session/new (issue: MCP never
         # registered). kiro-cli executes these itself (mcpCapabilities.http) —
@@ -668,48 +686,111 @@ class ACPClient:
         """
         Cache the model catalogue reported by ``session/new``.
 
-        kiro-cli returns a ``models`` object on every ``session/new``::
+        Two shapes are accepted, because the engines differ:
 
-            {"models": {"currentModelId": "...",
-                        "availableModels": [{"modelId", "name", "description"}, ...]}}
+        * **v1/v2** return a ``models`` object::
 
-        The list is normalised to ``{"id", "name", "description"}`` dicts and
-        cached so ``GET /v1/models`` can advertise the live catalogue instead of
-        a static fallback.
+              {"models": {"currentModelId": "...",
+                          "availableModels": [{"modelId", "name", "description"}, …]}}
+
+        * **v3** returns no ``models`` block at all — the catalogue arrives as a
+          ``configOptions`` select (verified against a live kiro-cli 2.18.0
+          probe)::
+
+              {"configOptions": [{"id": "model", "category": "model",
+                                  "currentValue": "…",
+                                  "options": [{"value", "name", "description"}, …]}]}
+
+        Both are normalised to ``{"id", "name", "description"}`` dicts and cached
+        so ``GET /v1/models`` advertises the live catalogue on either engine.
 
         Args:
             session_result: The raw ``session/new`` result dict.
         """
         models_info = session_result.get("models")
-        if not isinstance(models_info, dict):
+        if isinstance(models_info, dict):
+            current = models_info.get("currentModelId")
+            if isinstance(current, str) and current:
+                self._current_model_id = current
+            normalised = self._normalise_catalogue(models_info.get("availableModels"))
+            if normalised:
+                self._available_models = normalised
+                return
+        self._capture_config_option_catalogue(session_result.get("configOptions"))
+
+    def _capture_config_option_catalogue(self, config_options: Any) -> None:
+        """
+        Cache the model/mode catalogues carried by a v3 ``configOptions`` array.
+
+        Used both for ``session/new`` and for the ``config_option_update``
+        notification, which pushes a **replacement** array mid-session.
+
+        Args:
+            config_options: The raw ``configOptions`` value (ignored when it is
+                not a list, so v1/v2 results are unaffected).
+        """
+        if not isinstance(config_options, list):
             return
-        current = models_info.get("currentModelId")
-        if isinstance(current, str) and current:
-            self._current_model_id = current
-        available = models_info.get("availableModels")
-        if not isinstance(available, list):
-            return
+        for option in config_options:
+            if not isinstance(option, dict):
+                continue
+            option_id = str(option.get("id") or option.get("category") or "")
+            entries = self._normalise_catalogue(option.get("options"))
+            current = option.get("currentValue")
+            if option_id == "model":
+                if isinstance(current, str) and current:
+                    self._current_model_id = current
+                if entries:
+                    self._available_models = entries
+            elif option_id == "mode":
+                if isinstance(current, str) and current:
+                    self._current_mode_id = current
+                if entries:
+                    self._available_modes = entries
+
+    @staticmethod
+    def _normalise_catalogue(entries: Any) -> list[dict]:
+        """
+        Normalise a model/mode list to ``{"id", "name", "description"}`` dicts.
+
+        Accepts every id spelling the engines use: ``modelId`` (v2 models),
+        ``value`` (v3 configOptions options) and ``id`` (modes).
+
+        Args:
+            entries: The raw list of catalogue entries.
+
+        Returns:
+            The normalised entries, or ``[]`` when there is nothing usable.
+        """
+        if not isinstance(entries, list):
+            return []
         normalised: list[dict] = []
-        for entry in available:
+        for entry in entries:
             if not isinstance(entry, dict):
                 continue
-            model_id = entry.get("modelId")
-            if not model_id:
+            entry_id = entry.get("modelId") or entry.get("value") or entry.get("id")
+            if not entry_id:
                 continue
             normalised.append({
-                "id": str(model_id),
-                "name": str(entry.get("name") or model_id),
+                "id": str(entry_id),
+                "name": str(entry.get("name") or entry_id),
                 "description": str(entry.get("description") or ""),
             })
-        if normalised:
-            self._available_models = normalised
+        return normalised
 
     async def set_model(self, session_id: str, model_id: str) -> None:
         """
-        Select the model for an existing session via ``session/set_model``.
+        Select the model for an existing session.
 
-        kiro-cli accepts this request silently (it does not validate the id),
-        so an unknown model simply leaves the session on its default model.
+        The verb depends on the agent engine: v1/v2 use ``session/set_model``,
+        while the **v3 agent server implements no ``session/set_model``** and
+        exposes the model as a *session config option* instead — verified against
+        a live kiro-cli 2.18.0 probe (``session/new`` returns no ``models`` block,
+        only ``configOptions`` with an ``id: "model"`` select) and matching
+        first-party usage in ``kirodotdev/KiroCrew``. Same effect, different verb.
+
+        kiro-cli accepts the request silently (it does not validate the id), so
+        an unknown model simply leaves the session on its default model.
         Failures are logged and swallowed so a model-selection problem never
         breaks the completion itself.
 
@@ -718,6 +799,11 @@ class ACPClient:
             model_id: The model id requested by the caller (e.g.
                 ``claude-sonnet-4.6``).
         """
+        if not self._is_served("model", model_id, self._available_models):
+            return
+        if self._engine == "v3":
+            await self.set_config_option(session_id, "model", model_id)
+            return
         try:
             await self._call(
                 "session/set_model",
@@ -728,6 +814,88 @@ class ACPClient:
             logger.warning(
                 f"session/set_model failed for '{model_id}': {exc}; "
                 "session will use its default model"
+            )
+
+    def _is_served(self, kind: str, value: str, catalogue: list[dict]) -> bool:
+        """Whether a model/mode id is one kiro-cli actually serves.
+
+        An unserved id must not be put on the wire. The old assumption — that
+        kiro-cli silently keeps the session default for an unknown id — does not
+        hold: a live kiro-cli 2.18.0 probe with an id this account is not served
+        (the widely hardcoded ``claude-sonnet-4.6``) hung the turn for ~4 minutes
+        and then failed, as a ``504`` on v2 and as a misleading "Access denied.
+        Please check your authentication." on v3.
+
+        So when the live catalogue is known and the id is absent from it, the
+        selection is skipped and the session keeps the model ``session/new``
+        assigned. This matches what ``MODEL_VALIDATION=warn`` already reports
+        ("falling back to the session default") and mirrors first-party behaviour
+        in ``kirodotdev/KiroCrew`` ("this path never puts an unserved model on the
+        wire"). Harnesses that hardcode a foreign id keep working, and
+        ``MODEL_ALIASES`` can map one onto a served model.
+
+        Two deliberate escape hatches:
+
+        * the check is skipped while the catalogue is unknown (cold client), so a
+          selection is never withheld on a guess;
+        * ``MODEL_VALIDATION=off`` restores the legacy forward-everything
+          behaviour for operators who need to force an id.
+
+        Args:
+            kind: ``"model"`` or ``"mode"``, for logging.
+            value: The requested id.
+            catalogue: The cached catalogue to check against.
+
+        Returns:
+            ``True`` when the value may be sent.
+        """
+        if not catalogue:
+            return True
+        if str(getattr(settings, "MODEL_VALIDATION", "warn")).lower() == "off":
+            return True
+        served = {entry.get("id") for entry in catalogue}
+        if value in served:
+            return True
+        logger.warning(
+            f"{kind} '{value}' is not in kiro-cli's live catalogue "
+            f"({', '.join(sorted(str(s) for s in served))}); keeping the session "
+            f"default instead of sending an unserved {kind} "
+            f"(set MODEL_VALIDATION=off to force it)"
+        )
+        return False
+
+    async def set_config_option(
+        self, session_id: str, config_id: str, value: str
+    ) -> None:
+        """
+        Set a v3 session config option via ``session/set_config_option``.
+
+        The v3 agent server exposes the model, mode and thinking effort as
+        ``configOptions`` selects rather than dedicated ACP verbs. Failures are
+        logged and swallowed, mirroring :meth:`set_model` / :meth:`set_mode`: a
+        configuration problem must never break the completion itself.
+
+        Args:
+            session_id: The ACP session to configure.
+            config_id: The option id (``model`` / ``mode`` / ``effort``).
+            value: The option value to select.
+        """
+        try:
+            await self._call(
+                "session/set_config_option",
+                {"sessionId": session_id, "configId": config_id, "value": value},
+            )
+            if config_id == "model":
+                self._current_model_id = value
+            elif config_id == "mode":
+                self._current_mode_id = value
+            logger.info(
+                f"ACP session {session_id} config '{config_id}' set to '{value}'"
+            )
+        except ACPError as exc:
+            logger.warning(
+                f"session/set_config_option {config_id}='{value}' failed: {exc}; "
+                "session will use its default"
             )
 
     @property
@@ -744,8 +912,10 @@ class ACPClient:
             {"modes": {"currentModeId": "kiro_default",
                        "availableModes": [{"id", "name", "description"}, ...]}}
 
-        Each mode is an agent persona (``kiro_default``, ``code``,
-        ``kiro_planner``, ``kiro_guide``, …). The list is normalised to
+        Each mode is an agent persona. The ids are **engine-specific**:
+        v1/v2 use ``kiro_default``/``code``/``kiro_planner``/``kiro_guide``,
+        while v3 uses ``vibe``/``spec``/``plan``/``autonomous``/… (verified
+        against a live kiro-cli 2.18.0 probe). The list is normalised to
         ``{"id", "name", "description"}`` dicts and cached alongside the current
         mode id so the gateway can advertise/select the active agent.
 
@@ -758,21 +928,7 @@ class ACPClient:
         current = modes_info.get("currentModeId")
         if isinstance(current, str) and current:
             self._current_mode_id = current
-        available = modes_info.get("availableModes")
-        if not isinstance(available, list):
-            return
-        normalised: list[dict] = []
-        for entry in available:
-            if not isinstance(entry, dict):
-                continue
-            mode_id = entry.get("id")
-            if not mode_id:
-                continue
-            normalised.append({
-                "id": str(mode_id),
-                "name": str(entry.get("name") or mode_id),
-                "description": str(entry.get("description") or ""),
-            })
+        normalised = self._normalise_catalogue(modes_info.get("availableModes"))
         if normalised:
             self._available_modes = normalised
 
@@ -790,6 +946,8 @@ class ACPClient:
             session_id: The ACP session to configure.
             mode_id: The mode/agent id requested (e.g. ``kiro_planner``).
         """
+        if not self._is_served("mode", mode_id, self._available_modes):
+            return
         try:
             await self._call(
                 "session/set_mode",
@@ -1678,12 +1836,22 @@ class ACPClient:
             return
 
         session_id = params.get("sessionId", "")
+        update = params.get("update", {}) if isinstance(params, dict) else {}
+        if isinstance(update, dict) and update.get("sessionUpdate") == "config_option_update":
+            # v3 pushes a REPLACEMENT configOptions array when the model/mode/
+            # effort catalogue changes; keep the cached catalogue (used by
+            # GET /v1/models) in step. Handled before the queue lookup because it
+            # can arrive outside an active prompt. Not surfaced as a client event.
+            self._capture_config_option_catalogue(update.get("configOptions"))
+            return
+
         queue = self._event_queues.get(session_id)
         if not queue:
             return
 
         update = params.get("update", {})
         kind = update.get("sessionUpdate")
+
 
         # kiro-cli may attach token usage to an update or its params/_meta
         # (this is the same data its interactive /usage view shows). Capture it
@@ -1811,9 +1979,12 @@ class ACPClient:
     def _extract_tool_output(raw_output: Any) -> str:
         """Extract printable text from a tool call's ``rawOutput``.
 
-        kiro-cli returns ``rawOutput`` as ``{"items": [{"Text": "..."}, {"Json": …}]}``.
-        This concatenates the text items (and JSON-encodes structured items) into
-        a plain string for the activity/reasoning view.
+        The two engines report output differently (both verified live):
+
+        * **v1/v2** — ``{"items": [{"Text": "..."}, {"Json": …}]}``
+        * **v3** — ``{"output": "PROBE52_TOOL_MARKER\\n", …}`` (kiro-cli 2.18.0)
+
+        Both are reduced to a plain string for the activity/reasoning view.
 
         Args:
             raw_output: The ``rawOutput`` object from a ``tool_call_update``.
@@ -1825,6 +1996,13 @@ class ACPClient:
             return ""
         items = raw_output.get("items")
         if not isinstance(items, list):
+            # v3 shape: a flat string under "output" (or "stdout" on some tools).
+            for key in ("output", "stdout"):
+                value = raw_output.get(key)
+                if isinstance(value, str) and value:
+                    return value[:8000]
+                if value is not None and not isinstance(value, (dict, list)):
+                    return str(value)[:8000]
             return ""
         parts: list[str] = []
         for item in items:
@@ -1855,8 +2033,36 @@ class ACPClient:
             await self._respond(req_id, {"outcome": {"outcome": "selected", "optionId": option_id}})
             return
 
+        if method == AUTH_CALLBACK_METHOD:
+            # v3 only (issue #52): the agent server keeps no credential and asks
+            # the gateway for a short-lived access token, which the resolver
+            # obtains from kiro-cli itself. Connection-level request — it carries
+            # no sessionId, so it is answered directly. Declined when the bridge
+            # is disabled or the engine is not v3, which fails the turn with a
+            # clear auth error instead of relaying anything.
+            if self._auth_resolver is None:
+                await self._respond_error(
+                    req_id,
+                    AUTH_CALLBACK_ERROR_CODE,
+                    "kiro-cli authentication bridge is disabled; set "
+                    "ACP_AUTH_BRIDGE=true or use KIRO_ACP_ENGINE=v2",
+                )
+                return
+            try:
+                result = await self._auth_resolver.resolve()
+            except KiroAuthError as exc:
+                # The resolver guarantees a token-free message, so it is safe to
+                # log and to hand back to the agent.
+                logger.error(f"v3 auth callback failed: {exc}")
+                await self._respond_error(req_id, AUTH_CALLBACK_ERROR_CODE, str(exc))
+                return
+            await self._respond(req_id, result)
+            return
+
         # We advertise no fs/terminal capabilities, so kiro-cli should never
-        # ask us to perform them. If it does, decline cleanly.
+        # ask us to perform them. If it does, decline cleanly. This also covers
+        # v3's richer client-callback surface (_kiro/fs/*, hooks, checkpoints):
+        # declining keeps the gateway's least-privilege posture.
         await self._respond_error(req_id, -32601, f"{method} not supported by gateway")
 
     def _select_permission_option(self, options: list[dict],
@@ -1892,12 +2098,42 @@ class ACPClient:
         return select_option_id(options, approve)
 
     async def _respond(self, req_id: Any, result: Any) -> None:
-        await self._write_line(JsonRpcResponse(id=req_id, result=result).model_dump_json())
+        """Send a JSON-RPC success response to an agent request.
+
+        JSON-RPC 2.0 requires that a response carry **either** ``result`` or
+        ``error``, never both, so the unused ``error`` member is excluded. The v3
+        agent server reads ``result`` first and crashes on a ``null`` one
+        (``Cannot read properties of null``), so this is load-bearing, not
+        cosmetic.
+
+        Args:
+            req_id: The id of the request being answered.
+            result: The result payload (nested ``None`` values are preserved).
+        """
+        await self._write_line(
+            JsonRpcResponse(id=req_id, result=result).model_dump_json(
+                exclude={"error"}
+            )
+        )
 
     async def _respond_error(self, req_id: Any, code: int, message: str) -> None:
+        """Send a JSON-RPC error response to an agent request.
+
+        The ``result`` member is excluded for the same reason as in
+        :meth:`_respond`: a response carrying ``result: null`` next to ``error``
+        makes the v3 agent server take the null branch and report an opaque
+        ``-32603 Internal error`` instead of the message sent here.
+
+        Args:
+            req_id: The id of the request being answered.
+            code: The JSON-RPC error code.
+            message: A human-readable, credential-free error message.
+        """
         from kiro.acp_models import JsonRpcError
         await self._write_line(
-            JsonRpcResponse(id=req_id, error=JsonRpcError(code=code, message=message)).model_dump_json()
+            JsonRpcResponse(
+                id=req_id, error=JsonRpcError(code=code, message=message)
+            ).model_dump_json(exclude={"result"}, exclude_none=True)
         )
 
     # ------------------------------------------------------------------

--- a/kiro/acp_client.py
+++ b/kiro/acp_client.py
@@ -51,7 +51,7 @@ import os
 import re as _re
 import uuid
 from asyncio import Queue
-from typing import Any, AsyncIterator, Optional
+from typing import Any, AsyncIterator, Callable, Optional
 
 from loguru import logger
 
@@ -87,6 +87,36 @@ _STOP_REASON_MAP: dict[str, str] = {
     "refusal": "stop",
     "cancelled": "stop",
 }
+
+#: Session-scope ``kiro-cli acp`` flags each engine refuses outright, keyed by
+#: engine string. kiro-cli does not ignore an unsupported flag — it exits with
+#: ``error: the following arguments are not supported with --agent-engine=v3``
+#: before writing any JSON-RPC, so passing one breaks every request. Verified
+#: against a live kiro-cli 2.19.x probe; v3 replaces all of these with the
+#: ``permissions.yaml`` policy engine and per-session ACP methods. v1/v2 accept
+#: them, so their tuples stay empty and their argv is byte-identical to before.
+ENGINE_UNSUPPORTED_SPAWN_FLAGS: dict[str, tuple[str, ...]] = {
+    "v3": ("--agent", "--model", "--effort", "--trust-all-tools", "--trust-tools"),
+}
+
+#: Engines that ignore EOF on stdin and only exit when signalled. Verified
+#: against a live kiro-cli 2.19.x probe: a v3 ``acp`` process stayed alive
+#: indefinitely after stdin was closed, while v1/v2 exit promptly. Listing the
+#: engine here skips straight to SIGTERM so shutdown does not burn
+#: ``_STOP_STDIN_TIMEOUT`` on a stage that cannot succeed.
+ENGINES_IGNORING_STDIN_EOF: frozenset[str] = frozenset({"v3"})
+
+#: Bounded per-stage waits for the stdin-close → SIGTERM → SIGKILL shutdown
+#: escalation in :meth:`ACPClient.stop`. The stdin stage keeps the historical
+#: 5s budget for v1/v2 (which exit there); the signal stages are short because
+#: a process that ignored SIGTERM is not going to flush anything useful.
+_STOP_STDIN_TIMEOUT = 5.0
+_STOP_TERM_TIMEOUT = 3.0
+_STOP_KILL_TIMEOUT = 2.0
+
+#: Bound on the best-effort ``kiro-cli --version`` probe used when the engine
+#: reports no ``agentInfo`` (v3). Informational only, so it stays short.
+_VERSION_PROBE_TIMEOUT = 5.0
 
 
 def format_plan_text(entries: list, description: str = "") -> str:
@@ -484,6 +514,18 @@ class ACPClient:
         # survive the teardown of a disconnected streaming generator and can
         # be cleaned up on stop().
         self._cancel_tasks: set[asyncio.Task] = set()
+        # Agent -> gateway request handlers, scheduled off the read loop so a
+        # handler that shells out (the v3 _kiro/auth/getAccessToken callback runs
+        # `kiro-cli chat _ get-kas-token`) cannot block stdout demultiplexing.
+        # A strong reference is retained because asyncio only weakly references
+        # scheduled tasks: without this set the event loop may garbage-collect an
+        # in-flight handler mid-await, so the agent would wait forever for a
+        # reply that is never written.
+        self._agent_request_tasks: set[asyncio.Task] = set()
+        # Agent identity from initialize. The v3 engine reports no agentInfo, so
+        # these fall back to the binary's own --version (see _probe_cli_version).
+        self._agent_name: str = "kiro-cli"
+        self._agent_version: str | None = None
         self._write_lock = asyncio.Lock()
         self._initialized = False
         # Kept for backward-compatibility with older tests/callers.
@@ -520,26 +562,95 @@ class ACPClient:
 
         Deterministic order: base command, an explicit ``--agent-engine`` pin,
         then the optional ``--agent`` / ``--model`` / ``--effort`` flags (only
-        when set), then any raw ``extra_args`` appended verbatim. With nothing
-        configured this yields ``[command, "acp", "--agent-engine", "v2"]`` — the
-        same process as before plus an explicit engine pin (issue #53).
+        when set *and* supported by the selected engine), then any raw
+        ``extra_args`` appended verbatim. With nothing configured this yields
+        ``[command, "acp", "--agent-engine", "v2"]`` — the same process as before
+        plus an explicit engine pin (issue #53).
+
+        Session-scope flags are engine-gated because ``kiro-cli acp`` **hard
+        rejects** them on the v3 engine rather than ignoring them: verified
+        against a live kiro-cli 2.19.x probe, ``--agent``, ``--model``,
+        ``--effort``, ``--trust-all-tools`` and ``--trust-tools`` each make the
+        process exit immediately with ``error: the following arguments are not
+        supported with --agent-engine=v3``. Forwarding an operator's
+        ``KIRO_ACP_AGENT``/``KIRO_ACP_MODEL``/``KIRO_ACP_EFFORT`` to a v3 session
+        would therefore break *every* request instead of degrading, so the
+        unsupported flags are dropped with a warning and the per-request
+        ``session/set_model`` path continues to select the model.
 
         Returns:
             The argv list to spawn.
         """
         argv = [self._command, "acp", "--agent-engine", self._engine]
-        if self._agent:
-            argv += ["--agent", self._agent]
-        if self._initial_model:
-            argv += ["--model", self._initial_model]
-        if self._effort:
-            argv += ["--effort", self._effort]
+        spawn_flags = (
+            ("--agent", self._agent),
+            ("--model", self._initial_model),
+            ("--effort", self._effort),
+        )
+        dropped: list[str] = []
+        for flag, value in spawn_flags:
+            if not value:
+                continue
+            if flag in ENGINE_UNSUPPORTED_SPAWN_FLAGS.get(self._engine, ()):
+                dropped.append(flag)
+                continue
+            argv += [flag, value]
+        if dropped:
+            logger.warning(
+                f"kiro-cli engine {self._engine} does not accept "
+                f"{', '.join(dropped)} on 'acp'; dropping "
+                f"{'them' if len(dropped) > 1 else 'it'} so the session can "
+                "start (the requested model is still applied per request via "
+                "session/set_model)"
+            )
         argv += self._extra_args
         return argv
+
+    def _warn_restrictive_posture_on_v3(self) -> None:
+        """Warn when a restrictive tool posture cannot be fully guaranteed on v3.
+
+        ``ACP_TRUST_TOOLS`` and :class:`ToolPermissionPolicy` are enforced from
+        ``session/request_permission``, and that is engine-agnostic: verified
+        against a live kiro-cli 2.19.x v3 probe, answering ``reject_once``
+        genuinely blocks the tool (the model reported the command "was rejected,
+        so it didn't run"). So a refusing posture *is* honoured on v3 for every
+        tool kiro-cli asks about.
+
+        What differs on v3 is which tools it asks about. v3 decides that with its
+        own ``permissions.yaml`` policy engine (deny > ask > allow), and a tool
+        that policy already **allows** is executed without ever sending
+        ``session/request_permission`` — so the gateway is never consulted and
+        cannot refuse it. A user-scope ``capability: all -> allow`` rule
+        therefore silently pre-approves everything.
+
+        The gateway cannot close that from here: v3's ``acp`` subcommand rejects
+        ``--trust-all-tools``/``--trust-tools``/``--agent`` (see
+        :data:`ENGINE_UNSUPPORTED_SPAWN_FLAGS`) and ACP exposes no method to push
+        policy, so the only fix is a ``deny`` rule in kiro-cli's own policy —
+        which wins over every ``allow`` regardless of scope. Log it loudly rather
+        than let an operator believe an answer-only deployment is airtight.
+        """
+        if self._engine != "v3":
+            return
+        if self._trust_tools and not self._permission_policy.has_rules:
+            return
+        posture = (
+            "ACP_TRUST_TOOLS=false" if not self._trust_tools
+            else "ACP_TOOL_DENY/ACP_TOOL_ALLOW rules"
+        )
+        logger.warning(
+            f"{posture} is set on the v3 engine: the gateway refuses every tool "
+            "kiro-cli asks about, but v3 skips session/request_permission for "
+            "tools its own permissions.yaml already allows, and those cannot be "
+            "refused from here. For a hard guarantee add a deny rule to "
+            "~/.kiro/settings/permissions.yaml (deny beats allow in every "
+            "scope), or use KIRO_ACP_ENGINE=v2."
+        )
 
     async def start(self) -> None:
         """Spawn ``kiro-cli acp`` and begin reading its stdio."""
         argv = self._build_argv()
+        self._warn_restrictive_posture_on_v3()
         logger.info(f"Spawning ACP subprocess: {' '.join(argv)}")
         self._proc = await asyncio.create_subprocess_exec(
             *argv,
@@ -553,7 +664,20 @@ class ACPClient:
         logger.info(f"kiro-cli ACP subprocess started (pid={self._proc.pid})")
 
     async def stop(self) -> None:
-        """Gracefully stop the subprocess and cancel reader tasks."""
+        """Gracefully stop the subprocess and cancel reader tasks.
+
+        Shutdown escalates stdin-close → ``SIGTERM`` → ``SIGKILL``, each with its
+        own bounded wait, because closing stdin is **not** sufficient on every
+        engine: verified against a live kiro-cli 2.19.x probe, a v3 ``acp``
+        process ignores EOF on stdin and stays alive indefinitely (v1/v2 exit
+        promptly). Such engines are listed in
+        :data:`ENGINES_IGNORING_STDIN_EOF` and skip straight to the signal, so
+        shutdown does not stall for a timeout that cannot succeed. Without the
+        ``SIGTERM`` step the old code waited the full timeout and then sent
+        ``SIGKILL`` without reaping, which denied kiro-cli any chance to flush
+        and could leave a zombie behind. Each stage is awaited so the process is
+        reaped before returning.
+        """
         for task in (self._reader_task, self._stderr_task, *self._cancel_tasks):
             if task:
                 task.cancel()
@@ -562,17 +686,73 @@ class ACPClient:
                 except asyncio.CancelledError:
                     pass
         self._cancel_tasks.clear()
+        self._agent_request_tasks.clear()
         if self._proc and self._proc.returncode is None:
+            # Stage 1: EOF on stdin — the cooperative path (v1/v2 exit here).
+            # Skipped for engines known to ignore it, so shutdown is not delayed
+            # by a full timeout that cannot succeed.
+            exited = False
             try:
                 if self._proc.stdin and not self._proc.stdin.is_closing():
                     self._proc.stdin.close()
-                await asyncio.wait_for(self._proc.wait(), timeout=5.0)
-            except (asyncio.TimeoutError, ProcessLookupError, OSError):
-                try:
-                    self._proc.kill()
-                except ProcessLookupError:
-                    pass
+            except (OSError, ProcessLookupError):
+                pass
+            if self._engine in ENGINES_IGNORING_STDIN_EOF:
+                logger.debug(
+                    f"engine {self._engine} ignores stdin EOF; signalling directly"
+                )
+            else:
+                exited = await self._await_exit(_STOP_STDIN_TIMEOUT)
+            if not exited:
+                # Stage 2: SIGTERM — required for v3, which ignores stdin EOF.
+                if not await self._signal_and_wait(
+                    self._proc.terminate, _STOP_TERM_TIMEOUT
+                ):
+                    # Stage 3: SIGKILL — last resort, still reaped below.
+                    logger.warning(
+                        "kiro-cli ignored SIGTERM; sending SIGKILL"
+                    )
+                    await self._signal_and_wait(
+                        self._proc.kill, _STOP_KILL_TIMEOUT
+                    )
         logger.info("kiro-cli ACP subprocess stopped")
+
+    async def _await_exit(self, timeout: float) -> bool:
+        """Wait up to ``timeout`` seconds for the subprocess to exit.
+
+        Args:
+            timeout: Seconds to wait.
+
+        Returns:
+            True if the process has exited (or is already gone), else False.
+        """
+        if not self._proc:
+            return True
+        try:
+            await asyncio.wait_for(self._proc.wait(), timeout=timeout)
+            return True
+        except TimeoutError:
+            return False
+        except (ProcessLookupError, OSError):
+            # Already reaped by the event loop's child watcher.
+            return True
+
+    async def _signal_and_wait(self, signal_fn: Callable[[], None],
+                               timeout: float) -> bool:
+        """Send a termination signal and wait for the process to exit.
+
+        Args:
+            signal_fn: Bound ``terminate``/``kill`` of the subprocess.
+            timeout: Seconds to wait for the exit after signalling.
+
+        Returns:
+            True if the process has exited, else False.
+        """
+        try:
+            signal_fn()
+        except (ProcessLookupError, OSError):
+            return True
+        return await self._await_exit(timeout)
 
     async def initialize(
         self, capabilities: Optional[GatewayCapabilities] = None
@@ -602,7 +782,12 @@ class ACPClient:
         proto = "1"
         if isinstance(result, dict):
             proto = str(result.get("protocolVersion", 1))
-            agent = result.get("agentInfo", {})
+            # v3 omits agentInfo entirely and a malformed agent could send an
+            # explicit null, so neither `result["agentInfo"]` nor the two-arg
+            # `.get` default is safe on its own — normalise to a dict first.
+            agent = result.get("agentInfo")
+            if not isinstance(agent, dict):
+                agent = {}
             # Retain promptCapabilities so the prompt builder can pick a wire
             # representation per capability instead of assuming one: v3
             # advertises embeddedContext=true and reads ACP `resource` blocks,
@@ -613,12 +798,56 @@ class ACPClient:
                 if isinstance(prompt_caps, dict):
                     self._prompt_capabilities = prompt_caps
                     logger.info(f"ACP promptCapabilities: {prompt_caps}")
+            name = agent.get("name") or "kiro-cli"
+            version = agent.get("version")
+            if not version:
+                # The v3 engine reports no agentInfo, so fall back to asking the
+                # binary. Best-effort and cached: a missing version must never
+                # fail startup, it only degrades the log line and the property.
+                version = await self._probe_cli_version()
+            self._agent_name = name
+            self._agent_version = version
             logger.info(
-                f"ACP initialized: agent={agent.get('name', 'unknown')} "
-                f"v{agent.get('version', '?')} protocol={proto}"
+                f"ACP initialized: agent={name} v{version or '?'} "
+                f"protocol={proto} engine={self._engine}"
             )
         self._initialized = True
         return SessionInitResult(session_id="", protocol_version=proto)
+
+    async def _probe_cli_version(self) -> str | None:
+        """Best-effort ``kiro-cli --version`` lookup for engines without agentInfo.
+
+        Returns:
+            The version string (e.g. ``"2.19.2"``) or None when the binary cannot
+            be queried. Never raises: the version is informational only.
+        """
+        try:
+            proc = await asyncio.create_subprocess_exec(
+                self._command, "--version",
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.DEVNULL,
+            )
+            stdout, _ = await asyncio.wait_for(
+                proc.communicate(), timeout=_VERSION_PROBE_TIMEOUT
+            )
+        except (OSError, TimeoutError, ValueError) as exc:
+            logger.debug(f"kiro-cli version probe failed: {exc}")
+            return None
+        if proc.returncode != 0:
+            return None
+        # Output is "kiro-cli <version>"; take the last whitespace-separated token.
+        text = stdout.decode("utf-8", errors="replace").strip()
+        return text.split()[-1] if text else None
+
+    @property
+    def agent_name(self) -> str:
+        """Agent name from ``initialize``, or a sensible default."""
+        return self._agent_name
+
+    @property
+    def agent_version(self) -> str | None:
+        """Negotiated agent version, or the probed CLI version, else None."""
+        return self._agent_version
 
     @property
     def supports_embedded_context(self) -> bool:
@@ -1664,8 +1893,13 @@ class ACPClient:
         has_id = msg.get("id") is not None
 
         if method and has_id:
-            # Agent -> gateway request (e.g. session/request_permission).
-            asyncio.create_task(self._handle_agent_request(msg))
+            # Agent -> gateway request (e.g. session/request_permission, or the
+            # v3 auth callback). Scheduled off the read loop so a handler that
+            # shells out never blocks stdout demux, with a strong reference held
+            # until completion so the task cannot be garbage-collected mid-flight.
+            task = asyncio.create_task(self._handle_agent_request(msg))
+            self._agent_request_tasks.add(task)
+            task.add_done_callback(self._agent_request_tasks.discard)
             return
         if method:
             # Notification (no id) such as session/update.

--- a/kiro/acp_client.py
+++ b/kiro/acp_client.py
@@ -453,6 +453,9 @@ class ACPClient:
                 self._command, self._engine, settings.ACP_AUTH_BRIDGE
             )
         self._auth_resolver = auth_resolver
+        # Negotiated agentCapabilities.promptCapabilities from initialize. Empty
+        # until the handshake completes, so every capability defaults to off.
+        self._prompt_capabilities: dict = {}
         self._extra_args = list(extra_args or [])
         # Default MCP servers registered on every session/new (issue: MCP never
         # registered). kiro-cli executes these itself (mcpCapabilities.http) —
@@ -600,12 +603,34 @@ class ACPClient:
         if isinstance(result, dict):
             proto = str(result.get("protocolVersion", 1))
             agent = result.get("agentInfo", {})
+            # Retain promptCapabilities so the prompt builder can pick a wire
+            # representation per capability instead of assuming one: v3
+            # advertises embeddedContext=true and reads ACP `resource` blocks,
+            # while v1/v2 advertise false and silently ignore them (issue #58).
+            caps = result.get("agentCapabilities")
+            if isinstance(caps, dict):
+                prompt_caps = caps.get("promptCapabilities")
+                if isinstance(prompt_caps, dict):
+                    self._prompt_capabilities = prompt_caps
+                    logger.info(f"ACP promptCapabilities: {prompt_caps}")
             logger.info(
                 f"ACP initialized: agent={agent.get('name', 'unknown')} "
                 f"v{agent.get('version', '?')} protocol={proto}"
             )
         self._initialized = True
         return SessionInitResult(session_id="", protocol_version=proto)
+
+    @property
+    def supports_embedded_context(self) -> bool:
+        """Whether the agent accepts embedded document/context resource blocks.
+
+        Driven by the negotiated ``promptCapabilities.embeddedContext`` (issue
+        #58) — never by the engine string — so a future engine that gains or
+        loses the capability is handled without a code change. ``False`` until
+        ``initialize`` has reported otherwise, which keeps the text-reduction
+        path as the safe default.
+        """
+        return bool(self._prompt_capabilities.get("embeddedContext"))
 
     # ------------------------------------------------------------------
     # Sessions
@@ -1069,7 +1094,9 @@ class ACPClient:
         if not session_id:
             raise ACPError(-32602, "prompt_stream requires a session_id")
 
-        prompt_blocks = self._build_prompt_blocks(params.messages)
+        prompt_blocks = self._build_prompt_blocks(
+            params.messages, self.supports_embedded_context
+        )
         queue: Queue = Queue()
         self._event_queues[session_id] = queue
 
@@ -1359,7 +1386,7 @@ class ACPClient:
         return meta
 
     @staticmethod
-    def _build_prompt_blocks(messages: list) -> list[dict]:
+    def _build_prompt_blocks(messages: list, embed_documents: bool = False) -> list[dict]:
         """
         Render a conversation into ACP ``session/prompt`` content blocks.
 
@@ -1390,8 +1417,23 @@ class ACPClient:
         content — are emitted as their own ACP image content blocks **after** the
         text transcript, with an inline ``[image]`` marker left in the turn's
         text to mark where each appeared. The result is a mixed prompt array
-        ``[{text transcript}, {image}, …]`` (documents/audio are already reduced
-        to text by the shims; only images travel as binary blocks).
+        ``[{text transcript}, {image}, …]``.
+
+        **Documents (issue #58).** Representation follows the negotiated
+        ``promptCapabilities.embeddedContext``: when *embed_documents* is true
+        (the v3 agent engine) each document is emitted as an ACP ``resource``
+        block with an inline ``[document]`` marker, so the file travels intact;
+        otherwise it is reduced to its text fallback inline, as on v1/v2 — which
+        accept a resource block but silently ignore it.
+
+        Args:
+            messages: The conversation to serialise.
+            embed_documents: Whether the agent accepts embedded resource blocks
+                (``ACPClient.supports_embedded_context``). Defaults to ``False``,
+                the safe text-reduction behaviour.
+
+        Returns:
+            The ACP ``session/prompt`` content blocks.
         """
         label = {
             "user": "User",
@@ -1404,13 +1446,14 @@ class ACPClient:
         for m in messages:
             role = getattr(m, "role", None) if not isinstance(m, dict) else m.get("role")
             content = getattr(m, "content", None) if not isinstance(m, dict) else m.get("content")
-            text, images = ACPClient._split_content(content)
-            # Leave an inline marker per image so the (role-less) transcript
-            # still references where each attachment occurred, then carry the
-            # image as a real ACP block appended after the text.
-            for img in images:
-                text = (text + "\n[image]") if text else "[image]"
-                image_blocks.append(img)
+            text, attachments = ACPClient._split_content(content, embed_documents)
+            # Leave an inline marker per attachment so the (role-less) transcript
+            # still references where each occurred, then carry it as a real ACP
+            # block appended after the text.
+            for attachment in attachments:
+                marker = "[image]" if attachment.get("type") == "image" else "[document]"
+                text = (text + f"\n{marker}") if text else marker
+                image_blocks.append(attachment)
             parts.append((role or "user", text))
 
         blocks: list[dict] = []
@@ -1429,19 +1472,30 @@ class ACPClient:
         return blocks or [{"type": "text", "text": ""}]
 
     @staticmethod
-    def _split_content(content: Any) -> tuple[str, list[dict]]:
-        """Split message content into (flattened text, image content blocks).
+    def _split_content(content: Any, embed_documents: bool = False) -> tuple[str, list[dict]]:
+        """Split message content into (flattened text, attachment blocks).
 
-        Text and any non-image parts are flattened to a single string (as
-        :meth:`_flatten_content`), while ``image`` parts are extracted as ACP
-        image wire blocks (``{"type": "image", "mimeType", "data"}``) so the
-        prompt builder can forward them. Plain-string content yields no images.
+        Text parts are flattened to a single string, while ``image`` parts become
+        ACP image wire blocks (``{"type": "image", "mimeType", "data"}``).
+
+        ``document`` parts (issue #58) are represented per the negotiated
+        capability:
+
+        * ``embed_documents`` **True** (``promptCapabilities.embeddedContext``) →
+          an ACP embedded-resource block
+          ``{"type": "resource", "resource": {"uri", "mimeType", "text"|"blob"}}``
+          — the ``text`` variant when the document's text is known, else the
+          base64 ``blob`` so the agent parses the original bytes itself (a live
+          kiro-cli 2.18.0 probe read a PDF sent this way).
+        * **False** → the block's ``fallback`` text is appended to the flattened
+          text, exactly as before this feature (v1/v2 ignore resource blocks).
 
         Args:
             content: A message's content (``str`` or list of normalised blocks).
+            embed_documents: Whether the agent accepts embedded resources.
 
         Returns:
-            A ``(text, images)`` tuple.
+            A ``(text, blocks)`` tuple.
         """
         if content is None:
             return "", []
@@ -1458,12 +1512,50 @@ class ACPClient:
                             "mimeType": part.get("mimeType") or part.get("mime_type") or "image/png",
                             "data": part["data"],
                         })
+                    elif part.get("type") == "document":
+                        resource = ACPClient._document_resource_block(part) \
+                            if embed_documents else None
+                        if resource is not None:
+                            images.append(resource)
+                        else:
+                            chunks.append(str(part.get("fallback") or ""))
                     else:
                         chunks.append(str(part.get("text") or part.get("content") or ""))
                 else:
                     chunks.append(str(part))
             return "\n".join(c for c in chunks if c), images
         return str(content), []
+
+    @staticmethod
+    def _document_resource_block(part: dict) -> Optional[dict]:
+        """Build an ACP embedded-resource block for a normalised document part.
+
+        The wire shape is the ACP/MCP ``EmbeddedResource``: a ``resource`` object
+        carrying a required ``uri`` plus either ``text`` or ``blob`` (base64), all
+        verified accepted end-to-end against a live kiro-cli 2.18.0 / KAS 0.38.7
+        probe with both variants and with a synthetic ``attachment:///`` URI.
+
+        Args:
+            part: A normalised ``{"type": "document", …}`` block.
+
+        Returns:
+            The ACP content block, or ``None`` when the part carries neither text
+            nor data (so the caller falls back to text).
+        """
+        name = str(part.get("name") or "attachment").strip() or "attachment"
+        uri = f"attachment:///{name.lstrip('/')}"
+        resource: dict = {"uri": uri}
+        mime = part.get("mimeType") or part.get("mime_type")
+        if mime:
+            resource["mimeType"] = str(mime)
+        text = part.get("text")
+        if isinstance(text, str) and text:
+            resource["text"] = text
+        elif part.get("data"):
+            resource["blob"] = str(part["data"])
+        else:
+            return None
+        return {"type": "resource", "resource": resource}
 
     @staticmethod
     def _flatten_content(content: Any) -> str:

--- a/kiro/config.py
+++ b/kiro/config.py
@@ -434,12 +434,18 @@ ACP_MODEL: str = os.environ.get("KIRO_ACP_MODEL", "").strip()
 ACP_EFFORT: str = os.environ.get("KIRO_ACP_EFFORT", "").strip()
 # --agent-engine: "v1" | "v2" | "v3". Pinned explicitly to v2 (the current
 # kiro-cli default) so a future flip of the default engine cannot silently
-# change the gateway's behaviour. v3 currently requires host-mediated auth
-# that the gateway does not implement (see issue #52) — accepted syntactically
-# but not usable yet.
+# change the gateway's behaviour. v3 is supported (issue #52) but needs the
+# host-mediated auth bridge below, because `kiro-cli acp --agent-engine v3`
+# launches its agent server with a hardcoded `--auth=acp-callback`.
 _ACP_ENGINE_CHOICES = ("v1", "v2", "v3")
 _acp_engine_raw = os.environ.get("KIRO_ACP_ENGINE", "v2").strip().lower()
 ACP_ENGINE: str = _acp_engine_raw if _acp_engine_raw in _ACP_ENGINE_CHOICES else "v2"
+# Answer the v3 agent server's `_kiro/auth/getAccessToken` callback by relaying a
+# short-lived access token obtained from kiro-cli itself (see kiro/kiro_auth.py
+# and COMPLIANCE.md). Inert on v1/v2, where the callback is never sent, so the
+# gateway stays completely credential-free on the default engine. Set false to
+# make v3 fail closed instead of relaying a token.
+ACP_AUTH_BRIDGE: bool = os.environ.get("ACP_AUTH_BRIDGE", "true").lower() == "true"
 # Escape hatch: extra raw args appended verbatim to the acp argv, parsed with
 # shell-style quoting (e.g. KIRO_ACP_EXTRA_ARGS='--verbose --trust-tools fs_read').
 ACP_EXTRA_ARGS: str = os.environ.get("KIRO_ACP_EXTRA_ARGS", "").strip()
@@ -496,6 +502,7 @@ class _Settings:
     ACP_MODEL: str = field(default_factory=lambda: ACP_MODEL)
     ACP_EFFORT: str = field(default_factory=lambda: ACP_EFFORT)
     ACP_ENGINE: str = field(default_factory=lambda: ACP_ENGINE)
+    ACP_AUTH_BRIDGE: bool = field(default_factory=lambda: ACP_AUTH_BRIDGE)
     ACP_EXTRA_ARGS: str = field(default_factory=lambda: ACP_EXTRA_ARGS)
 
     # Feature flags (default enabled; override via env)

--- a/kiro/error_mapping.py
+++ b/kiro/error_mapping.py
@@ -28,6 +28,7 @@ secondary signal.
 | rate limit / throttle / quota / 429  | 429         | rate_limit_error| rate_limit_error   |
 | overloaded / unavailable / capacity  | 503         | server_error    | overloaded_error   |
 | timeout / deadline                   | 504         | server_error    | api_error          |
+| kiro-cli not authenticated           | 401         | authentication_error | authentication_error |
 | (default)                            | 502         | server_error    | api_error          |
 """
 from __future__ import annotations
@@ -55,6 +56,19 @@ _OVERLOADED_RE = re.compile(
 
 _TIMEOUT_RE = re.compile(
     r"(timed?\s*out|time[\s_-]?out|deadline\s+exceeded|\b504\b|\b408\b)",
+    re.IGNORECASE,
+)
+
+# kiro-cli's own credentials are unusable (expired / never logged in). Distinct
+# from the gateway's client auth: the remedy is `kiro-cli login` on the gateway
+# host. Matches the v3 auth-bridge failures (issue #52) — the agent server
+# reports a declined/failed `_kiro/auth/getAccessToken` as "Auth refresh callback
+# failed" / TokenExpiredError / TokenInvalidError (verified against a live
+# kiro-cli 2.18.0 probe) — as well as kiro-cli's own not-logged-in phrasings.
+_AUTH_RE = re.compile(
+    r"(auth\s+refresh\s+callback\s+failed|token\s*(?:expired|invalid)error|"
+    r"authentication\s+failed|not\s+logged\s+in|kiro-cli\s+login|"
+    r"authentication\s+bridge\s+is\s+disabled|expired\s+token|\b401\b)",
     re.IGNORECASE,
 )
 
@@ -173,6 +187,22 @@ def classify_error(
             openai_type="server_error",
             anthropic_type="api_error",
             retry_after=retry_after,
+        )
+
+    if _AUTH_RE.search(text):
+        # kiro-cli itself is not authenticated. 401 (rather than the generic 502)
+        # so harnesses surface a credential problem instead of retry-looping a
+        # gateway error. The message names the remedy; it never carries token
+        # material (see kiro.kiro_auth).
+        return MappedError(
+            status_code=401,
+            message=(
+                message
+                or "kiro-cli is not authenticated; run `kiro-cli login` on the "
+                   "gateway host"
+            ),
+            openai_type="authentication_error",
+            anthropic_type="authentication_error",
         )
 
     return MappedError(

--- a/kiro/kiro_auth.py
+++ b/kiro/kiro_auth.py
@@ -1,0 +1,281 @@
+# -*- coding: utf-8 -*-
+"""
+Resolver for the v3 agent engine's ``_kiro/auth/getAccessToken`` callback
+(issue #52).
+
+Why this exists
+---------------
+``kiro-cli acp --agent-engine v3`` does not run the agent itself: it spawns the
+Kiro Agent Server (KAS) and launches it with ``--auth=acp-callback``, which is
+hardcoded. Verified against a live kiro-cli 2.18.0 process::
+
+    node --experimental-wasm-modules …/@kiro/agent/dist/server/acp-server.js \\
+         --transport=stdio --auth=acp-callback
+
+In that mode KAS keeps **no** credential of its own and asks its ACP *client*
+for an access token. A client that declines still gets ``initialize`` and
+``session/new`` to succeed, but every ``session/prompt`` fails with
+``-32000 Auth refresh callback failed`` — the v3 blocker in issue #52.
+
+The gateway's job is a **passthrough**: kiro-cli owns the OIDC refresh token and
+exposes a subcommand that resolves-and-refreshes the access token, printing it as
+one JSON line::
+
+    kiro-cli chat _ get-kas-token
+    → {"kind": "getKasToken", "data": {"accessToken": …, "expiresAt": …,
+                                       "profileArn": …, "provider": …}}
+
+So no OIDC flow, no refresh logic and no token custody live here. This mirrors
+`kirodotdev/KiroCrew <https://github.com/kirodotdev/KiroCrew>`_ (a first-party
+Kiro project), whose ``acp/kas_auth.py`` answers the same callback the same way.
+
+Compliance position (deliberate, documented — see COMPLIANCE.md)
+---------------------------------------------------------------
+On the default ``v2`` engine nothing here ever runs and the gateway remains
+completely credential-free. On ``v3`` the gateway relays a short-lived access
+token **from kiro-cli to kiro-cli's own agent server**:
+
+* only the access token is handled — the OIDC **refresh token is never read**;
+* the token is **never cached, persisted or logged** (KAS caches it internally:
+  a live probe showed exactly one callback per subprocess);
+* only the covenant keys are forwarded, so no future kiro-cli field leaks onto
+  the wire unreviewed;
+* it is sent nowhere else — the gateway makes no HTTP call with it.
+
+Security notes
+--------------
+* Failure messages are **fixed strings**, never the subprocess output: a
+  malformed line could itself be a live token with trailing junk, so it must not
+  travel in an exception, a log record or a traceback.
+* The command is spawned with an argv **list** and no shell, so there is no
+  command-injection surface, and a timeout guarantees a hung kiro-cli cannot
+  wedge the callback (and with it every prompt on the connection).
+"""
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import json
+from typing import Any, Optional
+
+from loguru import logger
+
+#: The request the v3 agent server sends to its ACP client. Connection-level: it
+#: carries no ``sessionId``, so it is answered directly rather than routed to a
+#: session. Note the single-underscore ``_kiro/`` namespace, distinct from v2's
+#: ``_kiro.dev/`` one.
+AUTH_CALLBACK_METHOD = "_kiro/auth/getAccessToken"
+
+#: JSON-RPC error code returned when the callback cannot be fulfilled. KAS
+#: treats any rejection as an expired-token signal, so the exact code is not
+#: load-bearing; -32000 is the ACP server-error range.
+AUTH_CALLBACK_ERROR_CODE = -32000
+
+#: Subcommand that resolves + refreshes the KAS access token and prints one JSON
+#: line. This is a hidden kiro-cli IPC surface and may change without notice;
+#: failures are reported with an actionable message rather than papered over.
+_GET_KAS_TOKEN_ARGS = ("chat", "_", "get-kas-token")
+
+#: Marker kiro-cli puts on a successful token line.
+_TOKEN_KIND = "getKasToken"
+
+#: Hard cap on the callback subprocess. A refresh is a network round-trip, so
+#: allow room, but never let a hung process block the connection forever.
+_CALLBACK_TIMEOUT_SECONDS = 20.0
+
+#: The only keys forwarded to KAS, matching its ``GetAccessTokenResponse``.
+#: ``accessToken``/``expiresAt`` are required by KAS (which rejects a token
+#: expiring within 3 minutes); ``profileArn`` drives its AWS region (without it
+#: KAS falls back to ``us-east-1``); ``provider`` drives its enterprise
+#: governance path. Filtering — rather than forwarding ``data`` wholesale —
+#: keeps any future kiro-cli field off the wire until it is reviewed.
+_COVENANT_KEYS = ("accessToken", "expiresAt", "profileArn", "authMethod", "provider")
+
+
+class KiroAuthError(RuntimeError):
+    """A v3 auth callback could not be fulfilled.
+
+    Its ``str`` is always a fixed, token-free description — safe to log and to
+    send back as a JSON-RPC error message.
+    """
+
+
+class KiroAuthResolver:
+    """Resolves v3 access tokens by shelling out to kiro-cli.
+
+    Holds no state beyond configuration: every callback runs the official
+    command afresh, so no credential is retained between calls.
+    """
+
+    def __init__(
+        self,
+        cli_path: str = "kiro-cli",
+        timeout: float = _CALLBACK_TIMEOUT_SECONDS,
+    ) -> None:
+        """
+        Args:
+            cli_path: Path/name of the kiro-cli binary (``KIRO_CLI_PATH``).
+            timeout: Seconds to allow the token subprocess before killing it.
+        """
+        self._cli_path = cli_path or "kiro-cli"
+        self._timeout = timeout
+        self._disclosed = False
+
+    async def resolve(self) -> dict[str, Any]:
+        """Resolve a fresh access token as the ACP callback result payload.
+
+        Returns:
+            The ``_kiro/auth/getAccessToken`` result dict: ``accessToken`` and
+            ``expiresAt`` always, plus whichever of ``profileArn`` /
+            ``authMethod`` / ``provider`` kiro-cli supplied.
+
+        Raises:
+            KiroAuthError: When kiro-cli cannot be launched, times out, or does
+                not return a usable token. The message never contains token
+                material.
+        """
+        argv = [self._cli_path, *_GET_KAS_TOKEN_ARGS]
+        try:
+            proc = await asyncio.create_subprocess_exec(
+                *argv,
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.PIPE,
+            )
+        except (OSError, ValueError) as exc:
+            # A spawn failure carries no token: the text is a path/errno.
+            raise KiroAuthError(
+                f"could not launch kiro-cli for the v3 auth callback: {exc}"
+            ) from None
+
+        try:
+            stdout, stderr = await asyncio.wait_for(
+                proc.communicate(), timeout=self._timeout
+            )
+        except asyncio.TimeoutError:
+            with contextlib.suppress(ProcessLookupError):
+                proc.kill()
+            with contextlib.suppress(ProcessLookupError, asyncio.TimeoutError):
+                await asyncio.wait_for(proc.wait(), timeout=2.0)
+            raise KiroAuthError("kiro-cli token callback timed out") from None
+        except asyncio.CancelledError:
+            # Teardown cancelled this callback mid-flight: kill the credential
+            # subprocess synchronously so it cannot linger detached, and do not
+            # await here (we are unwinding a cancellation).
+            with contextlib.suppress(ProcessLookupError):
+                proc.kill()
+            raise
+
+        payload = parse_token_output(stdout, stderr)
+        self._disclose_once(payload)
+        return payload
+
+    def _disclose_once(self, payload: dict[str, Any]) -> None:
+        """Log the compliance-relevant disclosure once per process.
+
+        Args:
+            payload: The resolved covenant payload. Only non-secret fields
+                (expiry, presence flags) are logged — never the token.
+        """
+        if self._disclosed:
+            return
+        self._disclosed = True
+        logger.info(
+            "v3 auth bridge active: relaying kiro-cli's short-lived access token "
+            "to kiro-cli's own agent server (token not cached, refresh token "
+            "never read). "
+            f"expires_at={payload.get('expiresAt', 'unknown')} "
+            f"profile_arn={'set' if payload.get('profileArn') else 'unset'} "
+            f"provider={payload.get('provider') or 'unset'}"
+        )
+
+
+def parse_token_output(stdout: bytes, stderr: bytes) -> dict[str, Any]:
+    """Parse ``kiro-cli chat _ get-kas-token`` output into the ACP result.
+
+    Split out from the spawn so it is unit-testable without a real process.
+
+    Args:
+        stdout: Raw stdout from the token command.
+        stderr: Raw stderr, deliberately **not** surfaced (see below).
+
+    Returns:
+        The covenant-filtered result dict.
+
+    Raises:
+        KiroAuthError: On empty, unparseable or error output. The message is
+            always a fixed string: stdout/stderr are untrusted and could contain
+            token material, so they are dropped rather than echoed or logged.
+    """
+    text = stdout.decode("utf-8", "replace").strip()
+    if not text:
+        raise KiroAuthError(
+            "kiro-cli returned no token output; run `kiro-cli login` on the "
+            "gateway host"
+        )
+
+    # kiro-cli emits exactly one JSON line, but a stray leading log line must
+    # not derail the parse.
+    last_line = text.splitlines()[-1]
+    try:
+        obj = json.loads(last_line)
+    except (ValueError, TypeError):
+        # Never put the line in the message — it may be a live token.
+        raise KiroAuthError("could not parse kiro-cli token output") from None
+
+    if not isinstance(obj, dict):
+        raise KiroAuthError("kiro-cli token output was not a JSON object")
+
+    data = obj.get("data")
+    if not isinstance(data, dict):
+        raise KiroAuthError("kiro-cli token output had no data object")
+
+    kind = obj.get("kind")
+    if kind == "error":
+        # kiro-cli's own message is untrusted text; raise a fixed, actionable
+        # one instead and leave the specifics in kiro-cli's logs.
+        raise KiroAuthError(
+            "kiro-cli authentication failed; run `kiro-cli login` on the "
+            "gateway host"
+        )
+    if kind != _TOKEN_KIND:
+        raise KiroAuthError("unexpected kiro-cli token output kind")
+
+    if not data.get("accessToken"):
+        raise KiroAuthError("kiro-cli token output missing accessToken")
+    if not data.get("expiresAt"):
+        # KAS rejects a response whose expiresAt does not parse, so failing here
+        # gives a clearer error than its TokenInvalidError.
+        raise KiroAuthError("kiro-cli token output missing expiresAt")
+
+    return {key: data[key] for key in _COVENANT_KEYS if key in data}
+
+
+def build_resolver(
+    cli_path: str, engine: str, enabled: bool
+) -> Optional[KiroAuthResolver]:
+    """Build the auth resolver for a configured engine, or ``None``.
+
+    The resolver is only created for the ``v3`` engine: on ``v1``/``v2`` the
+    agent never sends the callback, so the gateway stays credential-free and its
+    behaviour is byte-identical to before this feature.
+
+    Args:
+        cli_path: Path/name of the kiro-cli binary.
+        engine: The configured ``--agent-engine`` value.
+        enabled: The ``ACP_AUTH_BRIDGE`` switch. When ``False`` the callback is
+            declined even on v3, so an operator who declines the credential
+            relay fails closed instead of relaying a token.
+
+    Returns:
+        A :class:`KiroAuthResolver`, or ``None`` when the bridge must not run.
+    """
+    if (engine or "").strip().lower() != "v3":
+        return None
+    if not enabled:
+        logger.warning(
+            "KIRO_ACP_ENGINE=v3 but ACP_AUTH_BRIDGE is disabled: the agent's "
+            "auth callback will be declined and generation will fail. "
+            "Set ACP_AUTH_BRIDGE=true or use KIRO_ACP_ENGINE=v2."
+        )
+        return None
+    return KiroAuthResolver(cli_path=cli_path)

--- a/kiro/multimodal.py
+++ b/kiro/multimodal.py
@@ -17,13 +17,27 @@ So the gateway:
   Only base64 data URLs are forwarded; a **remote URL is not fetched** (kiro-cli
   has no URL content-block capability, and fetching untrusted URLs server-side
   is an SSRF/egress risk) — it is surfaced as text instead.
-* **Documents — extracted when text, else placeholder.** kiro-cli rejects
-  embedded resources (``embeddedContext: false``), so documents are never
-  forwarded as binary. Text-like documents (``text/*``, JSON, XML, CSV, …) are
-  **decoded and injected as text** so the model actually reads them. PDFs are
-  extracted with ``pypdf`` (a standard dependency); a scanned/image-only PDF
-  that yields no text, or any other binary format, falls back to an explicit
-  ``[document: … omitted]`` placeholder — never a silent drop.
+* **Documents — embedded on v3, text-reduced otherwise (issue #58).** The
+  representation follows the negotiated ``promptCapabilities.embeddedContext``,
+  never the engine string:
+
+  - **``embeddedContext: true``** (the v3 agent engine) — the document travels
+    intact as an ACP ``resource`` content block, so the agent parses the
+    original bytes (PDF included). Verified against a live kiro-cli 2.18.0 /
+    KAS 0.38.7 probe: the model echoed markers embedded in both a ``text``
+    resource and a base64 ``blob`` PDF.
+  - **``embeddedContext: false``** (v1/v2) — the document is reduced to text, as
+    before. Text-like documents (``text/*``, JSON, XML, CSV, …) are **decoded
+    and injected**; PDFs are extracted with ``pypdf`` (a standard dependency); a
+    scanned/image-only PDF that yields no text, or any other binary format, gets
+    an explicit ``[document: … omitted]`` placeholder — never a silent drop.
+    The same probe showed v1/v2 accept a ``resource`` block **without error but
+    silently ignore it**, which is why this is capability-gated rather than
+    try-and-fall-back.
+
+  Every document block therefore carries both the payload (``data``/``text``)
+  and the ready-made ``fallback`` string, and
+  :meth:`ACPClient._build_prompt_blocks` picks one.
 * **Audio — placeholder.** Not supported by kiro-cli; surfaced as a placeholder.
 
 Normalized internal blocks (carried in :class:`~kiro.acp_models.PromptMessage`
@@ -146,9 +160,25 @@ def _document_block(
     name: Optional[str] = None,
     raw_text: Optional[str] = None,
 ) -> dict:
-    """Render a document attachment as a text block (extracted or placeholder).
+    """Normalize a document attachment, carrying both payload and text fallback.
 
-    Resolution order:
+    The returned block always includes ``fallback`` — the exact text
+    representation used when the agent cannot ingest embedded documents — so the
+    consumer can pick a representation from the negotiated capability
+    (issue #58) without re-deriving anything:
+
+    * ``promptCapabilities.embeddedContext`` **true** (v3 agent engine) →
+      :meth:`ACPClient._split_content` emits an ACP ``resource`` content block so
+      the document travels intact. Verified against a live kiro-cli 2.18.0 / KAS
+      0.38.7 probe: both a ``text`` resource and a base64 ``blob`` PDF were read
+      by the model (it echoed markers embedded in each).
+    * **false** (v1/v2) → the ``fallback`` text is injected instead, exactly as
+      before this feature. The same live probe showed v2 accepts a ``resource``
+      block **without error but silently ignores it** (the model reported seeing
+      no attachment), which is why this is capability-gated rather than
+      try-and-fall-back.
+
+    Fallback resolution order:
 
     1. ``raw_text`` provided directly (e.g. Anthropic ``text`` document source)
        → injected verbatim.
@@ -157,39 +187,48 @@ def _document_block(
        fails to parse).
     4. Anything else → explicit ``[document: … omitted]`` placeholder.
 
-    kiro-cli cannot ingest embedded documents (``embeddedContext: false``), so
-    the content always travels as text; this surfaces it instead of silently
-    dropping it.
-
     Args:
         mime: The document media type, if known.
         data: Base64-encoded document bytes, if present.
-        name: A display name (filename / title) for the placeholder.
+        name: A display name (filename / title) for the label/URI.
         raw_text: Already-decoded document text, if the source provided it.
 
     Returns:
-        A normalized text block — extracted content (labelled) or a placeholder.
+        A normalized ``{"type": "document", …}`` block.
     """
     label = name or (mime or "attachment")
+    text: Optional[str] = None
+    fallback: Optional[str] = None
 
     if raw_text:
-        return _text_block(_labelled_document(label, raw_text))
-
-    if data:
+        text = raw_text
+        fallback = _labelled_document(label, raw_text)
+    elif data:
         raw = _decode_base64(data)
         if raw is not None:
             if _is_text_mime(mime):
                 try:
-                    text = raw.decode("utf-8")
-                    return _text_block(_labelled_document(label, text))
+                    decoded = raw.decode("utf-8")
+                    text = decoded
+                    fallback = _labelled_document(label, decoded)
                 except UnicodeDecodeError:
                     logger.debug(f"document {label!r} not valid UTF-8; placeholder")
             elif (mime or "").lower().startswith("application/pdf"):
                 extracted = _extract_pdf_text(raw)
                 if extracted:
-                    return _text_block(_labelled_document(label, extracted))
+                    fallback = _labelled_document(label, extracted)
 
-    return _text_block(f"[document: {label} omitted — unsupported by kiro-cli]")
+    if fallback is None:
+        fallback = f"[document: {label} omitted — unsupported by kiro-cli]"
+
+    return {
+        "type": "document",
+        "mimeType": mime or "application/octet-stream",
+        "data": data,
+        "text": text,
+        "name": label,
+        "fallback": fallback,
+    }
 
 
 def _labelled_document(label: str, text: str) -> str:
@@ -345,23 +384,26 @@ def anthropic_block_to_blocks(block: Any) -> list[dict]:
 # ---------------------------------------------------------------------------
 
 def collapse_blocks(blocks: list[dict]) -> Any:
-    """Collapse normalized blocks to a ``str`` (no images) or a block ``list``.
+    """Collapse normalized blocks to a ``str`` (text only) or a block ``list``.
 
-    When no image is present the blocks are joined into a single newline-
-    separated string (the common, text-only case — keeps existing behaviour and
-    the labelled-transcript serialisation simple). When at least one image block
-    is present, the list is returned so :meth:`ACPClient._build_prompt_blocks`
-    can emit the images as separate ACP content blocks.
+    When the content is text only, the blocks are joined into a single newline-
+    separated string (the common case — keeps existing behaviour and the
+    labelled-transcript serialisation simple). When at least one image **or
+    document** block is present, the list is returned so
+    :meth:`ACPClient._build_prompt_blocks` can decide how to represent it:
+    images always travel as ACP image blocks, and documents travel either as
+    ACP ``resource`` blocks or as their text fallback depending on the
+    negotiated ``embeddedContext`` capability (issue #58).
 
     Args:
-        blocks: Normalized text/image blocks.
+        blocks: Normalized text/image/document blocks.
 
     Returns:
         ``str`` for text-only content, else the ``list[dict]`` of blocks.
     """
     if not blocks:
         return ""
-    if any(b.get("type") == "image" for b in blocks):
+    if any(b.get("type") in ("image", "document") for b in blocks):
         return blocks
     texts = [b.get("text", "") for b in blocks if b.get("type") == "text"]
     return "\n".join(t for t in texts if t)

--- a/main.py
+++ b/main.py
@@ -80,11 +80,21 @@ async def lifespan(app: FastAPI):
 
     logger.info(f"ACP engine: {settings.ACP_ENGINE}")
     if settings.ACP_ENGINE == "v3":
-        logger.warning(
-            "KIRO_ACP_ENGINE=v3 selected: the v3 engine requires host-mediated "
-            "auth (_kiro/auth/getAccessToken) that the gateway does not "
-            "implement, so generation will fail. See issue #52. Use v2."
-        )
+        if settings.ACP_AUTH_BRIDGE:
+            logger.info(
+                "KIRO_ACP_ENGINE=v3: the agent server is launched with "
+                "--auth=acp-callback, so the gateway relays a short-lived access "
+                "token obtained from kiro-cli itself (_kiro/auth/getAccessToken). "
+                "The refresh token is never read and no token is stored. "
+                "See COMPLIANCE.md and issue #52."
+            )
+        else:
+            logger.warning(
+                "KIRO_ACP_ENGINE=v3 with ACP_AUTH_BRIDGE=false: the agent's auth "
+                "callback will be declined, so generation will fail with an "
+                "authentication error. Set ACP_AUTH_BRIDGE=true or use "
+                "KIRO_ACP_ENGINE=v2."
+            )
     if settings.ACP_AGENT:
         logger.info(f"ACP spawn agent: {settings.ACP_AGENT}")
     if settings.ACP_MODEL:

--- a/tests/unit/test_acp_client.py
+++ b/tests/unit/test_acp_client.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 
 import asyncio
 import json
+import time
 from unittest.mock import AsyncMock, MagicMock, patch, PropertyMock
 
 import pytest
@@ -29,6 +30,9 @@ _REAL_PROMPT = ACPClient.prompt
 # Ditto for initialize: the capability-capture tests must exercise the real
 # handshake, not the session-scoped mock the ``test_client`` fixture installs.
 _REAL_INITIALIZE = ACPClient.initialize
+# And stop(): the shutdown-escalation tests must drive the real
+# stdin-close -> SIGTERM -> SIGKILL ladder, not the fixture's no-op mock.
+_REAL_STOP = ACPClient.stop
 
 
 # ---------------------------------------------------------------------------
@@ -631,6 +635,264 @@ class TestSpawnArgvConstruction:
         """A blank engine falls back to the explicit v2 pin."""
         client = ACPClient(engine="")
         assert client._build_argv()[:4] == ["kiro-cli", "acp", "--agent-engine", "v2"]
+
+    def test_v3_drops_session_scope_flags(self):
+        """v3 rejects --agent/--model/--effort outright, so they are dropped.
+
+        kiro-cli exits with "the following arguments are not supported with
+        --agent-engine=v3" before writing any JSON-RPC, so forwarding them would
+        break every request rather than degrade (verified live on 2.19.x).
+        """
+        client = ACPClient(
+            engine="v3", agent="planner",
+            initial_model="claude-sonnet-4.6", effort="high",
+        )
+        assert client._build_argv() == ["kiro-cli", "acp", "--agent-engine", "v3"]
+
+    def test_v3_still_appends_extra_args(self):
+        """extra_args stay an operator escape hatch even on v3."""
+        client = ACPClient(engine="v3", agent="planner", extra_args=["--verbose"])
+        assert client._build_argv() == [
+            "kiro-cli", "acp", "--agent-engine", "v3", "--verbose",
+        ]
+
+    @pytest.mark.parametrize("engine", ["v1", "v2"])
+    def test_v1_v2_keep_session_scope_flags(self, engine):
+        """v1/v2 accept the flags, so their argv is unchanged by the v3 gate."""
+        client = ACPClient(
+            engine=engine, agent="planner",
+            initial_model="claude-opus-4.8", effort="max",
+        )
+        assert client._build_argv() == [
+            "kiro-cli", "acp", "--agent-engine", engine,
+            "--agent", "planner", "--model", "claude-opus-4.8", "--effort", "max",
+        ]
+
+    def test_v3_drop_is_logged(self, caplog):
+        """Dropping a flag is surfaced, never silent."""
+        from loguru import logger as _logger
+
+        messages: list[str] = []
+        sink_id = _logger.add(lambda m: messages.append(m.record["message"]), level="WARNING")
+        try:
+            ACPClient(engine="v3", agent="planner")._build_argv()
+        finally:
+            _logger.remove(sink_id)
+        assert any("--agent" in m and "v3" in m for m in messages)
+
+
+class TestV3RestrictivePostureWarning:
+    """A refusing posture on v3 warns that pre-approved tools cannot be refused.
+
+    ACP_TRUST_TOOLS is enforced from session/request_permission and that works on
+    v3 (a live probe confirmed reject_once blocks the tool). But v3 skips the
+    request entirely for tools its own permissions.yaml allows, so the operator
+    must be told the posture is not airtight.
+    """
+
+    def _warnings(self, **kwargs) -> list[str]:
+        from loguru import logger as _logger
+
+        messages: list[str] = []
+        sink_id = _logger.add(lambda m: messages.append(m.record["message"]), level="WARNING")
+        try:
+            ACPClient(**kwargs)._warn_restrictive_posture_on_v3()
+        finally:
+            _logger.remove(sink_id)
+        return messages
+
+    def test_v3_with_trust_disabled_warns(self):
+        msgs = self._warnings(engine="v3", trust_tools=False)
+        assert any("permissions.yaml" in m for m in msgs)
+
+    def test_v3_with_deny_rules_warns(self):
+        from kiro.tool_permissions import ToolPermissionPolicy
+
+        policy = ToolPermissionPolicy.from_config("", "Bash(rm -rf *)", default_allow=True)
+        msgs = self._warnings(engine="v3", trust_tools=True, permission_policy=policy)
+        assert any("permissions.yaml" in m for m in msgs)
+
+    def test_v3_fully_trusting_does_not_warn(self):
+        from kiro.tool_permissions import ToolPermissionPolicy
+
+        policy = ToolPermissionPolicy.from_config("", "", default_allow=True)
+        assert self._warnings(
+            engine="v3", trust_tools=True, permission_policy=policy
+        ) == []
+
+    @pytest.mark.parametrize("engine", ["v1", "v2"])
+    def test_v1_v2_never_warn(self, engine):
+        """v1/v2 always ask, so the gateway's refusal is authoritative."""
+        assert self._warnings(engine=engine, trust_tools=False) == []
+
+
+class TestShutdownEscalation:
+    """stop() escalates stdin-close -> SIGTERM -> SIGKILL, reaping each stage.
+
+    Closing stdin is not enough on v3: a live probe showed the process ignoring
+    EOF and staying alive until signalled.
+    """
+
+    def _proc(self, exits_after: str) -> MagicMock:
+        """Build a fake process that only exits at the given stage."""
+        proc = MagicMock()
+        proc.returncode = None
+        proc.stdin = MagicMock()
+        proc.stdin.is_closing.return_value = False
+        state = {"stage": None}
+
+        async def wait():
+            if state["stage"] == exits_after:
+                return 0
+            await asyncio.sleep(3600)
+
+        proc.wait = wait
+        proc.stdin.close = MagicMock(side_effect=lambda: state.__setitem__("stage", "stdin"))
+        proc.terminate = MagicMock(side_effect=lambda: state.__setitem__("stage", "term"))
+        proc.kill = MagicMock(side_effect=lambda: state.__setitem__("stage", "kill"))
+        return proc
+
+    @pytest.mark.asyncio
+    async def test_exit_on_stdin_close_skips_signals(self):
+        """The cooperative v1/v2 path never signals the process."""
+        client = ACPClient()
+        client._proc = self._proc("stdin")
+
+        await _REAL_STOP(client)
+
+        client._proc.stdin.close.assert_called_once()
+        client._proc.terminate.assert_not_called()
+        client._proc.kill.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_sigterm_used_when_stdin_close_ignored(self, monkeypatch):
+        """v3 ignores stdin EOF, so SIGTERM is required — and SIGKILL is not."""
+        monkeypatch.setattr("kiro.acp_client._STOP_STDIN_TIMEOUT", 0.01)
+        client = ACPClient()
+        client._proc = self._proc("term")
+
+        await _REAL_STOP(client)
+
+        client._proc.terminate.assert_called_once()
+        client._proc.kill.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_sigkill_is_last_resort(self, monkeypatch):
+        """A process that ignores SIGTERM is killed and still reaped."""
+        monkeypatch.setattr("kiro.acp_client._STOP_STDIN_TIMEOUT", 0.01)
+        monkeypatch.setattr("kiro.acp_client._STOP_TERM_TIMEOUT", 0.01)
+        monkeypatch.setattr("kiro.acp_client._STOP_KILL_TIMEOUT", 0.01)
+        client = ACPClient()
+        client._proc = self._proc("kill")
+
+        await _REAL_STOP(client)
+
+        client._proc.terminate.assert_called_once()
+        client._proc.kill.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_v3_skips_the_stdin_wait(self):
+        """v3 ignores stdin EOF, so shutdown signals immediately instead of waiting.
+
+        The stdin timeout is left at its real 5s value: if the stage were not
+        skipped this test would take that long, so a regression shows up as a
+        slow test as well as a failed assertion.
+        """
+        client = ACPClient(engine="v3")
+        client._proc = self._proc("term")
+
+        started = time.monotonic()
+        await _REAL_STOP(client)
+        elapsed = time.monotonic() - started
+
+        client._proc.terminate.assert_called_once()
+        assert elapsed < 1.0
+
+    @pytest.mark.asyncio
+    async def test_already_exited_process_is_not_signalled(self):
+        """A process that already exited is left alone."""
+        client = ACPClient()
+        client._proc = self._proc("stdin")
+        client._proc.returncode = 0
+
+        await _REAL_STOP(client)
+
+        client._proc.terminate.assert_not_called()
+        client._proc.kill.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_missing_process_is_safe(self):
+        """stop() before start() must not raise."""
+        await _REAL_STOP(ACPClient())
+
+
+class TestAgentInfoFallback:
+    """initialize() tolerates a missing/None agentInfo (the v3 engine sends none)."""
+
+    @pytest.mark.asyncio
+    async def test_agent_info_is_used_when_present(self):
+        client = ACPClient()
+        client._call = AsyncMock(return_value={
+            "protocolVersion": 1,
+            "agentInfo": {"name": "Kiro CLI Agent", "version": "2.19.1"},
+        })
+        client._probe_cli_version = AsyncMock(return_value="should-not-be-used")
+
+        await _REAL_INITIALIZE(client)
+
+        assert client.agent_name == "Kiro CLI Agent"
+        assert client.agent_version == "2.19.1"
+        client._probe_cli_version.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_missing_agent_info_falls_back_to_cli_version(self):
+        """v3 omits agentInfo entirely, so the binary is asked instead."""
+        client = ACPClient(engine="v3")
+        client._call = AsyncMock(return_value={"protocolVersion": 1})
+        client._probe_cli_version = AsyncMock(return_value="2.19.2")
+
+        await _REAL_INITIALIZE(client)
+
+        assert client.agent_name == "kiro-cli"
+        assert client.agent_version == "2.19.2"
+
+    @pytest.mark.asyncio
+    async def test_null_agent_info_does_not_raise(self):
+        """An explicit null must not become an AttributeError."""
+        client = ACPClient()
+        client._call = AsyncMock(return_value={"protocolVersion": 1, "agentInfo": None})
+        client._probe_cli_version = AsyncMock(return_value=None)
+
+        result = await _REAL_INITIALIZE(client)
+
+        assert result.protocol_version == "1"
+        assert client.agent_version is None
+
+    @pytest.mark.asyncio
+    async def test_version_probe_parses_cli_output(self):
+        """`kiro-cli --version` prints "kiro-cli <version>"."""
+        client = ACPClient()
+        proc = MagicMock()
+        proc.returncode = 0
+        proc.communicate = AsyncMock(return_value=(b"kiro-cli 2.19.2\n", b""))
+        with patch("asyncio.create_subprocess_exec", AsyncMock(return_value=proc)):
+            assert await client._probe_cli_version() == "2.19.2"
+
+    @pytest.mark.asyncio
+    async def test_version_probe_failure_is_swallowed(self):
+        """A missing binary degrades the log line, never startup."""
+        client = ACPClient()
+        with patch("asyncio.create_subprocess_exec", AsyncMock(side_effect=OSError("nope"))):
+            assert await client._probe_cli_version() is None
+
+    @pytest.mark.asyncio
+    async def test_version_probe_nonzero_exit_returns_none(self):
+        client = ACPClient()
+        proc = MagicMock()
+        proc.returncode = 1
+        proc.communicate = AsyncMock(return_value=(b"", b"boom"))
+        with patch("asyncio.create_subprocess_exec", AsyncMock(return_value=proc)):
+            assert await client._probe_cli_version() is None
 
 
 class TestEngineConfigValidation:

--- a/tests/unit/test_acp_client.py
+++ b/tests/unit/test_acp_client.py
@@ -13,6 +13,7 @@ import pytest_asyncio
 
 from kiro.acp_client import ACPClient
 from kiro.acp_models import PromptMessage, PromptParams, ACPToolDefinition
+from kiro.config import settings
 
 # Capture the genuine new_session implementation at import time. The
 # session-scoped ``test_client`` fixture monkeypatches ``ACPClient.new_session``
@@ -2109,3 +2110,403 @@ class TestPromptStreamLimiting:
         await feeder
         texts = "".join(e["content"] for e in events if e["type"] == "text")
         assert texts == "one two three four five"
+
+
+# ---------------------------------------------------------------------------
+# v3 agent engine (issue #52): host-mediated auth callback, configOptions
+# catalogue, session/set_config_option and the v3 tool-output shape.
+# All shapes verified against a live kiro-cli 2.18.0 / KAS 0.38.7 probe.
+# ---------------------------------------------------------------------------
+
+class TestV3AuthCallback:
+    """``_kiro/auth/getAccessToken`` is answered only when the bridge is on."""
+
+    @staticmethod
+    def _capture_writes(client: ACPClient) -> list[str]:
+        written: list[str] = []
+
+        async def fake_write_line(line: str) -> None:
+            written.append(line)
+
+        client._write_line = fake_write_line  # type: ignore[assignment]
+        return written
+
+    @pytest.mark.asyncio
+    async def test_v3_answers_callback_with_resolver_payload(self):
+        from kiro.kiro_auth import KiroAuthResolver
+
+        resolver = MagicMock(spec=KiroAuthResolver)
+        resolver.resolve = AsyncMock(return_value={
+            "accessToken": "tok", "expiresAt": "2026-08-14T11:30:00Z",
+            "profileArn": "arn:aws:codewhisperer:us-east-1:1:profile/A",
+        })
+        client = ACPClient(engine="v3", auth_resolver=resolver)
+        written = self._capture_writes(client)
+
+        await client._handle_agent_request({
+            "jsonrpc": "2.0", "id": 0,
+            "method": "_kiro/auth/getAccessToken", "params": {},
+        })
+
+        assert len(written) == 1
+        msg = json.loads(written[0])
+        assert msg["id"] == 0
+        assert msg["result"]["accessToken"] == "tok"
+        assert "error" not in msg or msg["error"] is None
+
+    @pytest.mark.asyncio
+    async def test_resolver_failure_is_reported_as_jsonrpc_error(self):
+        from kiro.kiro_auth import KiroAuthError, KiroAuthResolver
+
+        resolver = MagicMock(spec=KiroAuthResolver)
+        resolver.resolve = AsyncMock(
+            side_effect=KiroAuthError("kiro-cli authentication failed; run `kiro-cli login`")
+        )
+        client = ACPClient(engine="v3", auth_resolver=resolver)
+        written = self._capture_writes(client)
+
+        await client._handle_agent_request({
+            "jsonrpc": "2.0", "id": 7,
+            "method": "_kiro/auth/getAccessToken", "params": {},
+        })
+
+        msg = json.loads(written[0])
+        assert msg["error"]["code"] == -32000
+        assert "kiro-cli login" in msg["error"]["message"]
+
+    @pytest.mark.asyncio
+    async def test_v2_declines_the_callback(self):
+        """On the default engine no resolver exists, so the callback is refused."""
+        client = ACPClient(engine="v2")
+        written = self._capture_writes(client)
+        assert client._auth_resolver is None
+
+        await client._handle_agent_request({
+            "jsonrpc": "2.0", "id": 1,
+            "method": "_kiro/auth/getAccessToken", "params": {},
+        })
+
+        msg = json.loads(written[0])
+        assert msg["error"]["code"] == -32000
+        assert "ACP_AUTH_BRIDGE" in msg["error"]["message"]
+
+    @pytest.mark.asyncio
+    async def test_v3_client_side_fs_requests_are_still_declined(self):
+        """v3 offers _kiro/fs/*; the gateway keeps its least-privilege posture."""
+        from kiro.kiro_auth import KiroAuthResolver
+
+        resolver = MagicMock(spec=KiroAuthResolver)
+        resolver.resolve = AsyncMock(return_value={"accessToken": "t", "expiresAt": "x"})
+        client = ACPClient(engine="v3", auth_resolver=resolver)
+        written = self._capture_writes(client)
+
+        for method in ("_kiro/fs/read", "_kiro/fs/write", "_kiro/fs/delete",
+                       "_kiro/hooks/executeHook", "_kiro/openExternalUrl"):
+            await client._handle_agent_request({
+                "jsonrpc": "2.0", "id": 1, "method": method, "params": {},
+            })
+
+        assert len(written) == 5
+        for line in written:
+            assert json.loads(line)["error"]["code"] == -32601
+
+
+class TestV3PermissionOptionIds:
+    """v3 advertises different optionIds; matching is by ``kind``."""
+
+    V3_OPTIONS = [
+        {"optionId": "accept", "name": "Allow", "kind": "allow_once"},
+        {"optionId": "always-accept", "name": "Always allow", "kind": "allow_always"},
+        {"optionId": "reject", "name": "Deny", "kind": "reject_once"},
+        {"optionId": "always-reject", "name": "Always deny", "kind": "reject_always"},
+    ]
+
+    def test_trusting_client_picks_v3_allow_once_id(self):
+        client = ACPClient(engine="v3", trust_tools=True)
+        assert client._select_permission_option(self.V3_OPTIONS, {}) == "accept"
+
+    def test_untrusting_client_picks_v3_reject_once_id(self):
+        client = ACPClient(engine="v3", trust_tools=False)
+        assert client._select_permission_option(self.V3_OPTIONS, {}) == "reject"
+
+
+class TestV3ConfigOptionsCatalogue:
+    """v3 reports the model/mode catalogue via configOptions, not ``models``."""
+
+    SESSION_NEW_V3 = {
+        "sessionId": "sess-v3",
+        "modes": {"availableModes": [{"id": "vibe", "name": "Default"}]},
+        "configOptions": [
+            {"type": "select", "id": "mode", "category": "mode",
+             "currentValue": "vibe",
+             "options": [{"value": "vibe", "name": "Default"},
+                         {"value": "plan", "name": "Plan"}]},
+            {"type": "select", "id": "model", "category": "model",
+             "currentValue": "claude-opus-5",
+             "options": [{"value": "auto", "name": "Auto", "description": "Auto"},
+                         {"value": "claude-opus-5", "name": "Claude Opus 5"}]},
+        ],
+    }
+
+    def test_models_come_from_config_options(self):
+        client = ACPClient(engine="v3")
+        client._capture_available_models(self.SESSION_NEW_V3)
+
+        assert [m["id"] for m in client.available_models] == ["auto", "claude-opus-5"]
+        assert client.available_models[1]["name"] == "Claude Opus 5"
+        assert client._current_model_id == "claude-opus-5"
+
+    def test_modes_come_from_config_options(self):
+        client = ACPClient(engine="v3")
+        client._capture_available_models(self.SESSION_NEW_V3)
+
+        assert [m["id"] for m in client.available_modes] == ["vibe", "plan"]
+        assert client._current_mode_id == "vibe"
+
+    def test_v2_models_block_still_wins(self):
+        """v1/v2 behaviour is unchanged when a models block is present."""
+        client = ACPClient(engine="v2")
+        client._capture_available_models({
+            "models": {"currentModelId": "claude-sonnet-4.6",
+                       "availableModels": [{"modelId": "claude-sonnet-4.6",
+                                            "name": "Sonnet"}]},
+            "configOptions": [{"id": "model", "currentValue": "ignored",
+                               "options": [{"value": "ignored"}]}],
+        })
+
+        assert [m["id"] for m in client.available_models] == ["claude-sonnet-4.6"]
+        assert client._current_model_id == "claude-sonnet-4.6"
+
+    def test_config_option_update_refreshes_catalogue(self):
+        client = ACPClient(engine="v3")
+        client._handle_notification({
+            "method": "session/update",
+            "params": {"sessionId": "sess-v3", "update": {
+                "sessionUpdate": "config_option_update",
+                "configOptions": [
+                    {"id": "model", "currentValue": "gpt-5.6-sol",
+                     "options": [{"value": "gpt-5.6-sol", "name": "GPT 5.6 Sol"}]},
+                ],
+            }},
+        })
+
+        assert [m["id"] for m in client.available_models] == ["gpt-5.6-sol"]
+        assert client._current_model_id == "gpt-5.6-sol"
+
+    def test_malformed_config_options_are_ignored(self):
+        client = ACPClient(engine="v3")
+        for payload in (None, [], "nope", [None, 3, {"id": "model"}]):
+            client._capture_available_models({"configOptions": payload})
+        assert client.available_models == []
+
+
+class TestV3ModelSelectionVerb:
+    """v3 has no session/set_model — the model is a session config option."""
+
+    @pytest.mark.asyncio
+    async def test_v3_uses_set_config_option(self):
+        client = ACPClient(engine="v3")
+        client._call = AsyncMock(return_value={})
+
+        await client.set_model("sess-1", "claude-opus-5")
+
+        client._call.assert_awaited_once_with(
+            "session/set_config_option",
+            {"sessionId": "sess-1", "configId": "model", "value": "claude-opus-5"},
+        )
+        assert client._current_model_id == "claude-opus-5"
+
+    @pytest.mark.asyncio
+    async def test_v2_still_uses_set_model(self):
+        client = ACPClient(engine="v2")
+        client._call = AsyncMock(return_value={})
+
+        await client.set_model("sess-1", "claude-sonnet-4.6")
+
+        client._call.assert_awaited_once_with(
+            "session/set_model",
+            {"sessionId": "sess-1", "modelId": "claude-sonnet-4.6"},
+        )
+
+    @pytest.mark.asyncio
+    async def test_set_config_option_failure_never_breaks_the_turn(self):
+        from kiro.acp_client import ACPError
+
+        client = ACPClient(engine="v3")
+        client._call = AsyncMock(side_effect=ACPError(-32000, "nope"))
+
+        await client.set_model("sess-1", "bogus-model")  # must not raise
+
+
+class TestUnservedModelGuard:
+    """An unserved model/mode is never put on the wire, on any engine.
+
+    A live kiro-cli 2.18.0 probe with an id this account is not served (the
+    widely hardcoded ``claude-sonnet-4.6``) hung the turn for ~4 minutes and then
+    failed — a 504 on v2 and a misleading "Access denied" on v3 — so the old
+    assumption that kiro-cli silently keeps its default does not hold.
+    """
+
+    @staticmethod
+    def _client(engine: str) -> ACPClient:
+        client = ACPClient(engine=engine)
+        client._available_models = [{"id": "auto"}, {"id": "claude-opus-5"}]
+        client._available_modes = [{"id": "vibe"}, {"id": "plan"}]
+        client._call = AsyncMock(return_value={})
+        return client
+
+    @pytest.mark.parametrize("engine", ["v2", "v3"])
+    @pytest.mark.asyncio
+    async def test_unserved_model_is_not_sent(self, engine):
+        client = self._client(engine)
+
+        await client.set_model("sess-1", "claude-sonnet-4.6")
+
+        client._call.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_served_model_is_sent_on_v3_as_config_option(self):
+        client = self._client("v3")
+
+        await client.set_model("sess-1", "claude-opus-5")
+
+        client._call.assert_awaited_once_with(
+            "session/set_config_option",
+            {"sessionId": "sess-1", "configId": "model", "value": "claude-opus-5"},
+        )
+
+    @pytest.mark.asyncio
+    async def test_served_model_is_sent_on_v2_as_set_model(self):
+        client = self._client("v2")
+
+        await client.set_model("sess-1", "claude-opus-5")
+
+        client._call.assert_awaited_once_with(
+            "session/set_model",
+            {"sessionId": "sess-1", "modelId": "claude-opus-5"},
+        )
+
+    @pytest.mark.asyncio
+    async def test_unknown_catalogue_does_not_block(self):
+        """A cold client cannot verify the id, so it must not withhold it."""
+        client = ACPClient(engine="v3")
+        client._call = AsyncMock(return_value={})
+
+        await client.set_model("sess-1", "anything")
+
+        client._call.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_model_validation_off_forces_the_id(self, monkeypatch):
+        """The legacy forward-everything behaviour stays available."""
+        monkeypatch.setattr(settings, "MODEL_VALIDATION", "off", raising=False)
+        client = self._client("v2")
+
+        await client.set_model("sess-1", "claude-sonnet-4.6")
+
+        client._call.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_unserved_mode_is_not_sent(self):
+        """A v2 mode id (e.g. kiro_default) must not be pushed to a v3 session."""
+        client = self._client("v3")
+
+        await client.set_mode("sess-1", "kiro_default")
+
+        client._call.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_served_mode_is_sent(self):
+        client = self._client("v3")
+
+        await client.set_mode("sess-1", "plan")
+
+        client._call.assert_awaited_once_with(
+            "session/set_mode", {"sessionId": "sess-1", "modeId": "plan"},
+        )
+
+
+class TestV3ToolOutputShape:
+    """v3 reports tool output as a flat string, v2 as an items list."""
+
+    def test_v3_flat_output_string(self):
+        assert ACPClient._extract_tool_output(
+            {"output": "PROBE52_TOOL_MARKER\n", "exitStatus": 0}
+        ) == "PROBE52_TOOL_MARKER\n"
+
+    def test_v2_items_list_unchanged(self):
+        assert ACPClient._extract_tool_output(
+            {"items": [{"Text": "l1"}, {"Text": "l2"}]}
+        ) == "l1\nl2"
+
+    def test_stdout_key_is_accepted(self):
+        assert ACPClient._extract_tool_output({"stdout": "hi"}) == "hi"
+
+    def test_no_recognised_key_yields_empty(self):
+        assert ACPClient._extract_tool_output({"unrelated": {"a": 1}}) == ""
+
+    def test_v3_output_reaches_the_tool_call_update_event(self):
+        client = ACPClient(engine="v3")
+        queue = asyncio.Queue()
+        client._event_queues["s"] = queue
+
+        client._handle_notification({
+            "method": "session/update",
+            "params": {"sessionId": "s", "update": {
+                "sessionUpdate": "tool_call_update", "toolCallId": "t1",
+                "title": "Run Command", "kind": "execute", "status": "completed",
+                "rawOutput": {"output": "hello-v3\n"},
+            }},
+        })
+
+        event = queue.get_nowait()
+        assert event["type"] == "tool_call_update"
+        assert event["output"] == "hello-v3\n"
+
+
+class TestAuthBridgeConfig:
+    """config.ACP_AUTH_BRIDGE gates the v3 credential relay (issue #52)."""
+
+    def _reload_config(self, monkeypatch, value):
+        import importlib
+        import kiro.config as cfg
+        if value is None:
+            monkeypatch.delenv("ACP_AUTH_BRIDGE", raising=False)
+        else:
+            monkeypatch.setenv("ACP_AUTH_BRIDGE", value)
+        return importlib.reload(cfg)
+
+    def test_default_is_enabled(self, monkeypatch):
+        """On by default — but inert unless the engine is v3."""
+        cfg = self._reload_config(monkeypatch, None)
+        try:
+            assert cfg.ACP_AUTH_BRIDGE is True
+            assert cfg.settings.ACP_AUTH_BRIDGE is True
+        finally:
+            self._reload_config(monkeypatch, None)
+
+    @pytest.mark.parametrize("value,expected", [
+        ("true", True), ("TRUE", True), ("false", False), ("0", False), ("", False),
+    ])
+    def test_env_parsing(self, monkeypatch, value, expected):
+        cfg = self._reload_config(monkeypatch, value)
+        try:
+            assert cfg.ACP_AUTH_BRIDGE is expected
+        finally:
+            self._reload_config(monkeypatch, None)
+
+    def test_disabled_bridge_leaves_v3_client_without_resolver(self, monkeypatch):
+        """A v3 client fails closed rather than relaying a credential."""
+        monkeypatch.setattr(settings, "ACP_AUTH_BRIDGE", False, raising=False)
+        assert ACPClient(engine="v3")._auth_resolver is None
+
+    def test_enabled_bridge_gives_v3_client_a_resolver(self, monkeypatch):
+        from kiro.kiro_auth import KiroAuthResolver
+
+        monkeypatch.setattr(settings, "ACP_AUTH_BRIDGE", True, raising=False)
+        assert isinstance(ACPClient(engine="v3")._auth_resolver, KiroAuthResolver)
+
+    def test_v2_client_never_gets_a_resolver(self, monkeypatch):
+        """The default engine stays completely credential-free."""
+        monkeypatch.setattr(settings, "ACP_AUTH_BRIDGE", True, raising=False)
+        assert ACPClient(engine="v2")._auth_resolver is None

--- a/tests/unit/test_acp_client.py
+++ b/tests/unit/test_acp_client.py
@@ -26,6 +26,9 @@ _REAL_NEW_SESSION = ACPClient.new_session
 _REAL_PROMPT_STREAM = ACPClient.prompt_stream
 # Same reason — the fixture also patches ACPClient.prompt for the session.
 _REAL_PROMPT = ACPClient.prompt
+# Ditto for initialize: the capability-capture tests must exercise the real
+# handshake, not the session-scoped mock the ``test_client`` fixture installs.
+_REAL_INITIALIZE = ACPClient.initialize
 
 
 # ---------------------------------------------------------------------------
@@ -2510,3 +2513,161 @@ class TestAuthBridgeConfig:
         """The default engine stays completely credential-free."""
         monkeypatch.setattr(settings, "ACP_AUTH_BRIDGE", True, raising=False)
         assert ACPClient(engine="v2")._auth_resolver is None
+
+
+# ---------------------------------------------------------------------------
+# Embedded documents (issue #58): representation follows the negotiated
+# promptCapabilities.embeddedContext, never the engine string.
+# Live kiro-cli 2.18.0 / KAS 0.38.7 probe: v3 advertises embeddedContext=true and
+# the model READ both a `text` resource and a base64 `blob` PDF; v2 advertises
+# false and silently IGNORES a resource block (the model saw no attachment).
+# ---------------------------------------------------------------------------
+
+class TestEmbeddedContextCapability:
+    """`supports_embedded_context` is driven by the initialize handshake."""
+
+    @pytest.mark.asyncio
+    async def test_false_before_initialize(self):
+        """Unknown capability must default to the safe text-reduction path."""
+        assert ACPClient().supports_embedded_context is False
+
+    @pytest.mark.asyncio
+    async def test_captured_from_initialize_v3(self):
+        client = ACPClient(engine="v3")
+        client._call = AsyncMock(return_value={
+            "protocolVersion": 1,
+            "agentCapabilities": {"promptCapabilities": {
+                "image": True, "embeddedContext": True}},
+        })
+
+        await _REAL_INITIALIZE(client)
+
+        assert client.supports_embedded_context is True
+
+    @pytest.mark.asyncio
+    async def test_captured_from_initialize_v2(self):
+        client = ACPClient(engine="v2")
+        client._call = AsyncMock(return_value={
+            "protocolVersion": 1,
+            "agentCapabilities": {"promptCapabilities": {
+                "image": True, "audio": False, "embeddedContext": False}},
+        })
+
+        await _REAL_INITIALIZE(client)
+
+        assert client.supports_embedded_context is False
+
+    @pytest.mark.asyncio
+    async def test_missing_capabilities_block_is_safe(self):
+        client = ACPClient()
+        client._call = AsyncMock(return_value={"protocolVersion": 1})
+
+        await _REAL_INITIALIZE(client)
+
+        assert client.supports_embedded_context is False
+
+
+class TestDocumentPromptRepresentation:
+    """A document renders as text (v1/v2) or an ACP resource block (v3)."""
+
+    TEXT_DOC = {
+        "type": "document", "mimeType": "text/markdown", "data": None,
+        "text": "# Spec\nbody", "name": "spec.md",
+        "fallback": "[document: spec.md]\n# Spec\nbody",
+    }
+    BINARY_DOC = {
+        "type": "document", "mimeType": "application/pdf", "data": "QUJD",
+        "text": None, "name": "scan.pdf",
+        "fallback": "[document: scan.pdf omitted — unsupported by kiro-cli]",
+    }
+
+    def _messages(self, doc: dict) -> list:
+        return [PromptMessage(role="user", content=[
+            {"type": "text", "text": "summarise this"}, doc,
+        ])]
+
+    def test_without_capability_document_is_reduced_to_text(self):
+        blocks = ACPClient._build_prompt_blocks(self._messages(self.TEXT_DOC), False)
+
+        assert [b["type"] for b in blocks] == ["text"]
+        assert "summarise this" in blocks[0]["text"]
+        assert "[document: spec.md]" in blocks[0]["text"]
+        assert "# Spec" in blocks[0]["text"]
+
+    def test_with_capability_text_document_becomes_a_resource(self):
+        blocks = ACPClient._build_prompt_blocks(self._messages(self.TEXT_DOC), True)
+
+        assert [b["type"] for b in blocks] == ["text", "resource"]
+        # The transcript keeps a marker where the attachment appeared.
+        assert "[document]" in blocks[0]["text"]
+        assert "[document: spec.md]" not in blocks[0]["text"]
+        resource = blocks[1]["resource"]
+        assert resource["text"] == "# Spec\nbody"
+        assert resource["mimeType"] == "text/markdown"
+        assert resource["uri"] == "attachment:///spec.md"
+        assert "blob" not in resource
+
+    def test_with_capability_binary_document_becomes_a_blob(self):
+        """A PDF travels as base64 so the agent parses it itself (probe-verified)."""
+        blocks = ACPClient._build_prompt_blocks(self._messages(self.BINARY_DOC), True)
+
+        resource = blocks[1]["resource"]
+        assert resource["blob"] == "QUJD"
+        assert resource["mimeType"] == "application/pdf"
+        assert "text" not in resource
+
+    def test_binary_document_without_capability_keeps_the_placeholder(self):
+        blocks = ACPClient._build_prompt_blocks(self._messages(self.BINARY_DOC), False)
+
+        assert [b["type"] for b in blocks] == ["text"]
+        assert "[document: scan.pdf omitted" in blocks[0]["text"]
+
+    def test_payloadless_document_falls_back_even_with_capability(self):
+        """Nothing to embed → the text fallback is used rather than a bad block."""
+        empty = {"type": "document", "mimeType": "application/zip", "data": None,
+                 "text": None, "name": "a.zip",
+                 "fallback": "[document: a.zip omitted — unsupported by kiro-cli]"}
+
+        blocks = ACPClient._build_prompt_blocks(self._messages(empty), True)
+
+        assert [b["type"] for b in blocks] == ["text"]
+        assert "[document: a.zip omitted" in blocks[0]["text"]
+
+    def test_images_and_documents_coexist(self):
+        messages = [PromptMessage(role="user", content=[
+            {"type": "text", "text": "look"},
+            {"type": "image", "mimeType": "image/png", "data": "aW1n"},
+            self.TEXT_DOC,
+        ])]
+
+        blocks = ACPClient._build_prompt_blocks(messages, True)
+
+        assert [b["type"] for b in blocks] == ["text", "image", "resource"]
+        assert "[image]" in blocks[0]["text"] and "[document]" in blocks[0]["text"]
+
+    def test_text_only_content_is_unaffected(self):
+        blocks = ACPClient._build_prompt_blocks(
+            [PromptMessage(role="user", content="just text")], True
+        )
+
+        assert blocks == [{"type": "text", "text": "just text"}]
+
+    def test_document_resource_block_shape(self):
+        """The wire shape matches ACP's EmbeddedResource (uri + text|blob)."""
+        block = ACPClient._document_resource_block(self.TEXT_DOC)
+
+        assert set(block) == {"type", "resource"}
+        assert block["type"] == "resource"
+        assert set(block["resource"]) == {"uri", "mimeType", "text"}
+
+    def test_document_resource_block_none_without_payload(self):
+        assert ACPClient._document_resource_block(
+            {"type": "document", "name": "x", "data": None, "text": None}
+        ) is None
+
+    def test_unnamed_document_still_gets_a_uri(self):
+        block = ACPClient._document_resource_block(
+            {"type": "document", "text": "x", "name": ""}
+        )
+
+        assert block["resource"]["uri"] == "attachment:///attachment"

--- a/tests/unit/test_error_mapping.py
+++ b/tests/unit/test_error_mapping.py
@@ -148,3 +148,71 @@ class TestClassifyExceptionAndEvent:
         mapped = classify_event({"type": "error"})
         assert mapped.status_code == 502
         assert mapped.message == "Unknown error"
+
+
+class TestAuthClassification:
+    """kiro-cli's own credentials being unusable maps to 401 (issue #52).
+
+    Distinct from the gateway's client auth: the remedy is `kiro-cli login` on
+    the gateway host. The messages below are the ones the v3 agent server and
+    the auth bridge actually produce (verified against a live kiro-cli 2.18.0
+    probe: declining the callback fails session/prompt with
+    "-32000 Auth refresh callback failed").
+    """
+
+    @pytest.mark.parametrize("message", [
+        "Auth refresh callback failed: not supported",
+        "[TokenExpiredError] Auth refresh callback failed",
+        "TokenInvalidError: host returned no access token",
+        "kiro-cli authentication failed; run `kiro-cli login`",
+        "kiro-cli authentication bridge is disabled; set ACP_AUTH_BRIDGE=true",
+        "upstream returned 401",
+    ])
+    def test_auth_failures_map_to_401(self, message):
+        assert classify_error(message).status_code == 401
+
+    def test_auth_error_types_are_native(self):
+        mapped = classify_error("Auth refresh callback failed")
+        assert mapped.openai_type == "authentication_error"
+        assert mapped.anthropic_type == "authentication_error"
+
+    def test_auth_message_names_the_remedy_when_empty(self):
+        """Signal in structured data, empty message -> the fallback names the fix."""
+        mapped = classify_error("", data={"message": "Auth refresh callback failed"})
+        assert mapped.status_code == 401
+        assert "kiro-cli login" in mapped.message
+
+    def test_auth_envelopes_render_in_both_shapes(self):
+        mapped = classify_error("Auth refresh callback failed")
+        assert mapped.to_openai_error()["error"]["type"] == "authentication_error"
+        assert mapped.to_anthropic_error()["error"]["type"] == "authentication_error"
+
+    def test_rate_limit_still_wins_over_auth(self):
+        """A throttled auth-bearing message stays retryable (429), not 401."""
+        assert classify_error(
+            "429 rate limit exceeded while refreshing token"
+        ).status_code == 429
+
+    def test_timeout_still_wins_over_auth(self):
+        assert classify_error(
+            "kiro-cli token callback timed out"
+        ).status_code == 504
+
+    def test_exception_path_classifies_auth(self):
+        """Non-streaming completions surface ACPError -> 401."""
+        exc = ACPError(-32000, "Auth refresh callback failed: not supported")
+        assert classify_exception(exc).status_code == 401
+
+    def test_event_path_classifies_auth(self):
+        """Streaming error events classify identically to the exception path."""
+        event = {"type": "error", "code": -32000,
+                 "message": "Auth refresh callback failed: not supported"}
+        assert classify_event(event).status_code == 401
+
+    def test_auth_carries_no_retry_after(self):
+        """Retrying without re-login cannot help, so no Retry-After is set."""
+        assert classify_error("Auth refresh callback failed").headers() == {}
+
+    def test_ordinary_failures_are_unaffected(self):
+        """The word 'token' alone must not trip the auth class."""
+        assert classify_error("max output tokens reached").status_code == 502

--- a/tests/unit/test_kiro_auth.py
+++ b/tests/unit/test_kiro_auth.py
@@ -1,0 +1,238 @@
+# -*- coding: utf-8 -*-
+"""
+Unit tests for kiro.kiro_auth — the v3 ``_kiro/auth/getAccessToken`` resolver.
+
+The resolver relays a short-lived access token obtained from kiro-cli to
+kiro-cli's own agent server (issue #52). These tests pin the parts that matter
+for compliance and security: the covenant-key filter, the fact that failures
+never leak token material, and that the bridge is inert on v1/v2.
+
+No real kiro-cli process is spawned: the subprocess is mocked throughout.
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from kiro.kiro_auth import (
+    AUTH_CALLBACK_ERROR_CODE,
+    AUTH_CALLBACK_METHOD,
+    KiroAuthError,
+    KiroAuthResolver,
+    build_resolver,
+    parse_token_output,
+)
+
+TOKEN = "fake-access-token-value"
+EXPIRY = "2026-08-14T11:30:00.031719222Z"
+ARN = "arn:aws:codewhisperer:us-east-1:111122223333:profile/ABCDEF"
+
+
+def _token_line(**overrides) -> bytes:
+    """Build a ``kiro-cli chat _ get-kas-token`` style stdout line."""
+    data = {
+        "accessToken": TOKEN,
+        "expiresAt": EXPIRY,
+        "profileArn": ARN,
+        "provider": "Enterprise",
+    }
+    data.update(overrides)
+    return (json.dumps({"kind": "getKasToken", "data": data}) + "\n").encode()
+
+
+class TestParseTokenOutputSuccess:
+    """A well-formed token line becomes the ACP callback result."""
+
+    def test_covenant_keys_forwarded(self):
+        result = parse_token_output(_token_line(), b"")
+
+        assert result == {
+            "accessToken": TOKEN,
+            "expiresAt": EXPIRY,
+            "profileArn": ARN,
+            "provider": "Enterprise",
+        }
+
+    def test_unknown_fields_are_not_forwarded(self):
+        """Only covenant keys reach the wire, so new CLI fields can't leak."""
+        raw = json.dumps({
+            "kind": "getKasToken",
+            "data": {"accessToken": TOKEN, "expiresAt": EXPIRY,
+                     "refreshToken": "MUST-NOT-BE-FORWARDED",
+                     "someFutureField": "x"},
+        }).encode()
+
+        result = parse_token_output(raw, b"")
+
+        assert set(result) == {"accessToken", "expiresAt"}
+        assert "refreshToken" not in result
+        assert "someFutureField" not in result
+
+    def test_optional_keys_omitted_when_absent(self):
+        result = parse_token_output(
+            json.dumps({"kind": "getKasToken",
+                        "data": {"accessToken": TOKEN, "expiresAt": EXPIRY}}).encode(),
+            b"",
+        )
+
+        assert result == {"accessToken": TOKEN, "expiresAt": EXPIRY}
+
+    def test_leading_log_line_is_tolerated(self):
+        """Only the last stdout line is parsed."""
+        raw = b"[INFO] some kiro-cli log noise\n" + _token_line()
+
+        assert parse_token_output(raw, b"")["accessToken"] == TOKEN
+
+
+class TestParseTokenOutputErrors:
+    """Failures raise a fixed, token-free message."""
+
+    def test_empty_output_names_the_remedy(self):
+        with pytest.raises(KiroAuthError) as excinfo:
+            parse_token_output(b"", b"")
+
+        assert "kiro-cli login" in str(excinfo.value)
+
+    def test_error_kind_does_not_echo_upstream_message(self):
+        """kiro-cli's own message is untrusted and must not be surfaced."""
+        raw = json.dumps({
+            "kind": "error",
+            "data": {"message": f"boom {TOKEN} leaked"},
+        }).encode()
+
+        with pytest.raises(KiroAuthError) as excinfo:
+            parse_token_output(raw, b"")
+
+        assert TOKEN not in str(excinfo.value)
+        assert "kiro-cli login" in str(excinfo.value)
+
+    def test_unparseable_line_is_not_echoed(self):
+        """A malformed line could itself be a live token — never repeat it."""
+        with pytest.raises(KiroAuthError) as excinfo:
+            parse_token_output(f"{TOKEN} trailing junk".encode(), b"")
+
+        assert TOKEN not in str(excinfo.value)
+
+    def test_stderr_is_never_surfaced(self):
+        with pytest.raises(KiroAuthError) as excinfo:
+            parse_token_output(b"", f"stderr with {TOKEN}".encode())
+
+        assert TOKEN not in str(excinfo.value)
+
+    @pytest.mark.parametrize("payload", [
+        {"kind": "getKasToken"},                                  # no data
+        {"kind": "getKasToken", "data": []},                      # data not a dict
+        {"kind": "somethingElse", "data": {"accessToken": TOKEN}},  # wrong kind
+        {"kind": "getKasToken", "data": {"expiresAt": EXPIRY}},    # no token
+        {"kind": "getKasToken", "data": {"accessToken": TOKEN}},   # no expiry
+    ])
+    def test_malformed_payloads_raise(self, payload):
+        with pytest.raises(KiroAuthError):
+            parse_token_output(json.dumps(payload).encode(), b"")
+
+    def test_non_object_json_raises(self):
+        with pytest.raises(KiroAuthError):
+            parse_token_output(b'["not", "an", "object"]', b"")
+
+
+class TestResolveSubprocess:
+    """resolve() shells out to kiro-cli without a shell and honours a timeout."""
+
+    @pytest.mark.asyncio
+    async def test_resolve_returns_payload_and_uses_argv_list(self):
+        proc = AsyncMock()
+        proc.communicate = AsyncMock(return_value=(_token_line(), b""))
+
+        with patch("asyncio.create_subprocess_exec",
+                   AsyncMock(return_value=proc)) as spawn:
+            resolver = KiroAuthResolver(cli_path="/usr/bin/kiro-cli")
+            result = await resolver.resolve()
+
+        assert result["accessToken"] == TOKEN
+        # argv list (no shell string) => no command-injection surface.
+        assert spawn.await_args.args == (
+            "/usr/bin/kiro-cli", "chat", "_", "get-kas-token",
+        )
+
+    @pytest.mark.asyncio
+    async def test_resolve_is_not_cached(self):
+        """Each callback re-runs the command; no token is retained."""
+        proc = AsyncMock()
+        proc.communicate = AsyncMock(return_value=(_token_line(), b""))
+
+        with patch("asyncio.create_subprocess_exec",
+                   AsyncMock(return_value=proc)) as spawn:
+            resolver = KiroAuthResolver()
+            await resolver.resolve()
+            await resolver.resolve()
+
+        assert spawn.await_count == 2
+        assert not any("token" in str(v).lower() and TOKEN in str(v)
+                       for v in vars(resolver).values())
+
+    @pytest.mark.asyncio
+    async def test_spawn_failure_raises_auth_error(self):
+        with patch("asyncio.create_subprocess_exec",
+                   AsyncMock(side_effect=OSError("no such file"))):
+            with pytest.raises(KiroAuthError) as excinfo:
+                await KiroAuthResolver().resolve()
+
+        assert "could not launch kiro-cli" in str(excinfo.value)
+
+    @pytest.mark.asyncio
+    async def test_timeout_kills_process_and_raises(self):
+        proc = AsyncMock()
+        proc.communicate = AsyncMock(side_effect=asyncio.TimeoutError)
+        proc.wait = AsyncMock()
+        proc.kill = lambda: setattr(proc, "killed", True)
+
+        with patch("asyncio.create_subprocess_exec", AsyncMock(return_value=proc)):
+            with pytest.raises(KiroAuthError) as excinfo:
+                await KiroAuthResolver(timeout=0.01).resolve()
+
+        assert "timed out" in str(excinfo.value)
+        assert getattr(proc, "killed", False) is True
+
+    @pytest.mark.asyncio
+    async def test_cancellation_kills_process_and_propagates(self):
+        """Teardown must not leave a credential subprocess running detached."""
+        proc = AsyncMock()
+        proc.communicate = AsyncMock(side_effect=asyncio.CancelledError)
+        proc.kill = lambda: setattr(proc, "killed", True)
+
+        with patch("asyncio.create_subprocess_exec", AsyncMock(return_value=proc)):
+            with pytest.raises(asyncio.CancelledError):
+                await KiroAuthResolver().resolve()
+
+        assert getattr(proc, "killed", False) is True
+
+
+class TestBuildResolver:
+    """The bridge only exists for v3, and only when enabled."""
+
+    @pytest.mark.parametrize("engine", ["v1", "v2", "V2", "", None])
+    def test_non_v3_engines_get_no_resolver(self, engine):
+        assert build_resolver("kiro-cli", engine, True) is None
+
+    def test_v3_enabled_builds_resolver(self):
+        assert isinstance(build_resolver("kiro-cli", "v3", True), KiroAuthResolver)
+
+    def test_v3_case_insensitive(self):
+        assert isinstance(build_resolver("kiro-cli", "V3", True), KiroAuthResolver)
+
+    def test_v3_disabled_fails_closed(self):
+        """ACP_AUTH_BRIDGE=false must not relay a credential."""
+        assert build_resolver("kiro-cli", "v3", False) is None
+
+
+class TestConstants:
+    """The wire-level constants match the live v3 protocol."""
+
+    def test_method_name(self):
+        assert AUTH_CALLBACK_METHOD == "_kiro/auth/getAccessToken"
+
+    def test_error_code_in_server_range(self):
+        assert AUTH_CALLBACK_ERROR_CODE == -32000

--- a/tests/unit/test_multimodal.py
+++ b/tests/unit/test_multimodal.py
@@ -82,9 +82,11 @@ class TestOpenAIParts:
             "filename": "notes.txt",
             "file_data": f"data:text/plain;base64,{HELLO_B64}",
         })
-        assert blocks[0]["type"] == "text"
-        assert "[document: notes.txt]" in blocks[0]["text"]
-        assert "hello world" in blocks[0]["text"]
+        assert blocks[0]["type"] == "document"
+        assert "[document: notes.txt]" in blocks[0]["fallback"]
+        assert "hello world" in blocks[0]["fallback"]
+        # The decoded text is retained so v3 can embed it as a resource (#58).
+        assert blocks[0]["text"] == "hello world"
 
     def test_binary_document_without_pypdf_is_placeholder(self):
         blocks = openai_part_to_blocks({
@@ -92,8 +94,11 @@ class TestOpenAIParts:
             "filename": "report.pdf",
             "file_data": f"data:application/pdf;base64,{HELLO_B64}",
         })
-        assert blocks[0]["type"] == "text"
-        assert "[document: report.pdf omitted" in blocks[0]["text"]
+        assert blocks[0]["type"] == "document"
+        assert "[document: report.pdf omitted" in blocks[0]["fallback"]
+        # No extracted text, but the bytes survive for the v3 resource path.
+        assert blocks[0]["text"] is None
+        assert blocks[0]["data"]
 
     def test_audio_is_placeholder(self):
         blocks = openai_part_to_blocks({"type": "input_audio", "input_audio": {"data": "x"}})
@@ -134,24 +139,25 @@ class TestAnthropicBlocks:
             "type": "document", "title": "spec.md",
             "source": {"type": "text", "media_type": "text/markdown", "data": "# Title\nbody"},
         })
-        assert blocks[0]["type"] == "text"
-        assert "[document: spec.md]" in blocks[0]["text"]
-        assert "# Title" in blocks[0]["text"]
+        assert blocks[0]["type"] == "document"
+        assert "[document: spec.md]" in blocks[0]["fallback"]
+        assert "# Title" in blocks[0]["fallback"]
+        assert blocks[0]["text"] == "# Title\nbody"
 
     def test_document_base64_text_extracted(self):
         blocks = anthropic_block_to_blocks({
             "type": "document", "title": "data.csv",
             "source": {"type": "base64", "media_type": "text/csv", "data": HELLO_B64},
         })
-        assert "[document: data.csv]" in blocks[0]["text"]
-        assert "hello world" in blocks[0]["text"]
+        assert "[document: data.csv]" in blocks[0]["fallback"]
+        assert "hello world" in blocks[0]["fallback"]
 
     def test_document_binary_placeholder(self):
         blocks = anthropic_block_to_blocks({
             "type": "document", "title": "scan.pdf",
             "source": {"type": "base64", "media_type": "application/pdf", "data": HELLO_B64},
         })
-        assert "[document: scan.pdf omitted" in blocks[0]["text"]
+        assert "[document: scan.pdf omitted" in blocks[0]["fallback"]
 
     def test_tool_use_marker(self):
         blocks = anthropic_block_to_blocks({
@@ -206,9 +212,9 @@ class TestPdfExtraction:
             "type": "input_file", "filename": "invoice.pdf",
             "file_data": f"data:application/pdf;base64,{pdf_b64}",
         })
-        assert blocks[0]["type"] == "text"
-        assert "[document: invoice.pdf]" in blocks[0]["text"]
-        assert "Invoice total 42 EUR" in blocks[0]["text"]
+        assert blocks[0]["type"] == "document"
+        assert "[document: invoice.pdf]" in blocks[0]["fallback"]
+        assert "Invoice total 42 EUR" in blocks[0]["fallback"]
 
     def test_invalid_pdf_bytes_degrade_to_placeholder(self):
         """Non-PDF bytes labelled as PDF parse-fail gracefully → placeholder."""
@@ -217,7 +223,7 @@ class TestPdfExtraction:
             "type": "input_file", "filename": "broken.pdf",
             "file_data": f"data:application/pdf;base64,{bad}",
         })
-        assert "[document: broken.pdf omitted" in blocks[0]["text"]
+        assert "[document: broken.pdf omitted" in blocks[0]["fallback"]
 
     def test_pdf_extracted_when_available(self, monkeypatch):
         import kiro.multimodal as mm
@@ -227,8 +233,8 @@ class TestPdfExtraction:
             "type": "input_file", "filename": "r.pdf",
             "file_data": f"data:application/pdf;base64,{HELLO_B64}",
         })
-        assert "[document: r.pdf]" in blocks[0]["text"]
-        assert "EXTRACTED PDF TEXT" in blocks[0]["text"]
+        assert "[document: r.pdf]" in blocks[0]["fallback"]
+        assert "EXTRACTED PDF TEXT" in blocks[0]["fallback"]
 
     def test_pdf_placeholder_when_extraction_returns_none(self, monkeypatch):
         import kiro.multimodal as mm
@@ -238,7 +244,7 @@ class TestPdfExtraction:
             "type": "input_file", "filename": "r.pdf",
             "file_data": f"data:application/pdf;base64,{HELLO_B64}",
         })
-        assert "[document: r.pdf omitted" in blocks[0]["text"]
+        assert "[document: r.pdf omitted" in blocks[0]["fallback"]
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_routes_anthropic_shim.py
+++ b/tests/unit/test_routes_anthropic_shim.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 import json
 
 import pytest
+from kiro.acp_client import ACPClient
 
 
 # ---------------------------------------------------------------------------
@@ -763,8 +764,14 @@ class TestAnthropicShimMultimodal:
         resp = sync_client.post("/v1/messages", json=payload, headers=anthropic_headers)
         assert resp.status_code == 200
         content = rec.complete_kwargs[0]["messages"][-1].content
-        assert isinstance(content, str)
-        assert "[document: spec.md]" in content and "# Spec" in content
+        doc = next(b for b in content if b.get("type") == "document")
+        assert "[document: spec.md]" in doc["fallback"] and "# Spec" in doc["fallback"]
+        # v1/v2 rendering (no embeddedContext) keeps the text reduction.
+        blocks = ACPClient._build_prompt_blocks(
+            rec.complete_kwargs[0]["messages"], False
+        )
+        assert "[document: spec.md]" in blocks[0]["text"]
+        assert "# Spec" in blocks[0]["text"]
 
     def test_messages_binary_document_placeholder(self, sync_client, anthropic_headers):
         rec = _RecordingShim()
@@ -779,7 +786,16 @@ class TestAnthropicShimMultimodal:
         }
         resp = sync_client.post("/v1/messages", json=payload, headers=anthropic_headers)
         assert resp.status_code == 200
-        assert "[document: scan.pdf omitted" in rec.complete_kwargs[0]["messages"][-1].content
+        content = rec.complete_kwargs[0]["messages"][-1].content
+        doc = next(b for b in content if b.get("type") == "document")
+        assert "[document: scan.pdf omitted" in doc["fallback"]
+        # A binary document with no extractable text still travels intact on v3.
+        blocks = ACPClient._build_prompt_blocks(
+            rec.complete_kwargs[0]["messages"], True
+        )
+        resource = next(b for b in blocks if b["type"] == "resource")["resource"]
+        assert resource["blob"] == "QUJD"
+        assert resource["mimeType"] == "application/pdf"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_routes_anthropic_shim.py
+++ b/tests/unit/test_routes_anthropic_shim.py
@@ -916,6 +916,29 @@ class TestAnthropicShimErrorMapping:
         assert resp.status_code == 502
         assert resp.json()["error"]["type"] == "api_error"
 
+    # -- v3 auth bridge failures (issue #52) -------------------------------
+    # kiro-cli itself not being authenticated must surface as a native 401
+    # authentication_error in BOTH modes, matching the OpenAI shim.
+
+    def test_non_stream_auth_failure_returns_401(self, sync_client, anthropic_headers):
+        sync_client.app.state.shim_service = _anthropic_error_shim_complete(
+            ACPError(-32000, "Auth refresh callback failed: not supported")
+        )
+        resp = sync_client.post("/v1/messages", json=self._MSG, headers=anthropic_headers)
+        assert resp.status_code == 401
+        body = resp.json()
+        assert body["type"] == "error"
+        assert body["error"]["type"] == "authentication_error"
+
+    def test_stream_auth_failure_error_type(self, sync_client, anthropic_headers):
+        sync_client.app.state.shim_service = _anthropic_error_shim_stream(
+            {"type": "error", "message": "Auth refresh callback failed", "code": -32000}
+        )
+        payload = {**self._MSG, "stream": True}
+        resp = sync_client.post("/v1/messages", json=payload, headers=anthropic_headers)
+        assert resp.status_code == 200  # SSE body already started
+        assert '"type": "authentication_error"' in resp.text
+
     def test_stream_rate_limit_error_type(self, sync_client, anthropic_headers):
         sync_client.app.state.shim_service = _anthropic_error_shim_stream(
             {"type": "error", "message": "rate limit exceeded", "code": -32000}

--- a/tests/unit/test_routes_openai_shim.py
+++ b/tests/unit/test_routes_openai_shim.py
@@ -8,6 +8,7 @@ import json
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+from kiro.acp_client import ACPClient
 
 
 # ---------------------------------------------------------------------------
@@ -610,9 +611,16 @@ class TestOpenAIShimMultimodal:
         resp = sync_client.post("/v1/chat/completions", json=payload, headers=openai_headers)
         assert resp.status_code == 200
         content = rec.complete_kwargs[0]["messages"][-1].content
-        # No image → collapses to a string carrying the placeholder.
-        assert isinstance(content, str)
-        assert "[document: r.pdf omitted" in content
+        # The document is carried as a block so the client can pick a wire
+        # representation from the negotiated capability (issue #58)...
+        doc = next(b for b in content if b.get("type") == "document")
+        assert "[document: r.pdf omitted" in doc["fallback"]
+        # ...and without embeddedContext (v1/v2) it still renders as that text.
+        blocks = ACPClient._build_prompt_blocks(
+            rec.complete_kwargs[0]["messages"], False
+        )
+        assert "[document: r.pdf omitted" in blocks[0]["text"]
+        assert all(b["type"] == "text" for b in blocks)
 
     def test_chat_text_document_is_extracted(self, sync_client, openai_headers):
         rec = _RecordingShim()
@@ -627,7 +635,21 @@ class TestOpenAIShimMultimodal:
         resp = sync_client.post("/v1/chat/completions", json=payload, headers=openai_headers)
         assert resp.status_code == 200
         content = rec.complete_kwargs[0]["messages"][-1].content
-        assert "hello world" in content
+        doc = next(b for b in content if b.get("type") == "document")
+        assert "hello world" in doc["fallback"]
+        # v1/v2 rendering (no embeddedContext) injects the extracted text.
+        blocks = ACPClient._build_prompt_blocks(
+            rec.complete_kwargs[0]["messages"], False
+        )
+        assert "hello world" in blocks[0]["text"]
+        # v3 rendering (embeddedContext) sends it as an ACP resource block.
+        blocks = ACPClient._build_prompt_blocks(
+            rec.complete_kwargs[0]["messages"], True
+        )
+        resource = next(b for b in blocks if b["type"] == "resource")["resource"]
+        assert resource["text"] == "hello world"
+        assert resource["mimeType"] == "text/plain"
+        assert resource["uri"].endswith("n.txt")
 
     def test_responses_input_image_forwarded(self, sync_client, openai_headers):
         rec = _RecordingShim()

--- a/tests/unit/test_routes_openai_shim.py
+++ b/tests/unit/test_routes_openai_shim.py
@@ -805,6 +805,51 @@ class TestOpenAIShimErrorMapping:
         assert '"type": "rate_limit_error"' in resp.text
         assert "data: [DONE]" in resp.text
 
+    # -- v3 auth bridge failures (issue #52) -------------------------------
+    # kiro-cli itself not being authenticated must surface as a native 401
+    # authentication_error, not a generic 502, in BOTH modes.
+
+    def test_chat_non_stream_auth_failure_returns_401(self, sync_client, openai_headers):
+        sync_client.app.state.shim_service = _error_shim_complete(
+            ACPError(-32000, "Auth refresh callback failed: not supported")
+        )
+        resp = sync_client.post("/v1/chat/completions", json=self._CHAT, headers=openai_headers)
+        assert resp.status_code == 401
+        assert resp.json()["error"]["type"] == "authentication_error"
+
+    def test_chat_stream_auth_failure_error_type(self, sync_client, openai_headers):
+        sync_client.app.state.shim_service = _error_shim_stream(
+            {"type": "error", "message": "Auth refresh callback failed", "code": -32000}
+        )
+        payload = {**self._CHAT, "stream": True}
+        resp = sync_client.post("/v1/chat/completions", json=payload, headers=openai_headers)
+        assert resp.status_code == 200  # SSE body already started
+        assert '"type": "authentication_error"' in resp.text
+        assert "data: [DONE]" in resp.text
+
+    def test_responses_non_stream_auth_failure_returns_401(self, sync_client, openai_headers):
+        sync_client.app.state.shim_service = _error_shim_complete(
+            ACPError(-32000, "kiro-cli authentication failed; run `kiro-cli login`")
+        )
+        resp = sync_client.post(
+            "/v1/responses", json={"model": "claude-sonnet-4.6", "input": "hi"},
+            headers=openai_headers,
+        )
+        assert resp.status_code == 401
+        assert resp.json()["error"]["type"] == "authentication_error"
+
+    def test_responses_stream_auth_failure_error_type(self, sync_client, openai_headers):
+        sync_client.app.state.shim_service = _error_shim_stream(
+            {"type": "error", "message": "Auth refresh callback failed", "code": -32000}
+        )
+        resp = sync_client.post(
+            "/v1/responses",
+            json={"model": "claude-sonnet-4.6", "input": "hi", "stream": True},
+            headers=openai_headers,
+        )
+        assert resp.status_code == 200
+        assert "authentication_error" in resp.text
+
     def test_responses_non_stream_rate_limit_returns_429(self, sync_client, openai_headers):
         sync_client.app.state.shim_service = _error_shim_complete(
             ACPError(-32000, "Too Many Requests")

--- a/tests/unit/test_tool_permissions.py
+++ b/tests/unit/test_tool_permissions.py
@@ -318,6 +318,33 @@ class TestSelectOptionId:
         assert select_option_id(options, True) == "allow-this-once"
 
 
+class TestV3PermissionOptionShape:
+    """The v3 engine offers different optionIds than v1/v2 — match on `kind`.
+
+    Captured verbatim from a live kiro-cli 2.19.x v3 ``session/request_permission``
+    (title "printf <marker>"). The ids are ``accept``/``reject`` rather than
+    ``allow_once``/``reject_once``, so any id-based matching would silently invert
+    the decision. Answering the ``reject`` id was confirmed to block execution.
+    """
+
+    V3_OPTIONS = [
+        {"optionId": "accept", "kind": "allow_once", "name": "Accept"},
+        {"optionId": "always-accept", "kind": "allow_always", "name": "Always accept"},
+        {"optionId": "reject", "kind": "reject_once", "name": "Reject"},
+        {"optionId": "always-reject", "kind": "reject_always", "name": "Always reject"},
+    ]
+
+    def test_refuse_picks_the_v3_reject_id(self):
+        assert select_option_id(self.V3_OPTIONS, False) == "reject"
+
+    def test_approve_picks_the_v3_accept_id(self):
+        assert select_option_id(self.V3_OPTIONS, True) == "accept"
+
+    def test_refuse_never_selects_an_accept_id(self):
+        """Guards the fail-safe: refusing must never resolve to an allow option."""
+        assert select_option_id(self.V3_OPTIONS, False) not in {"accept", "always-accept"}
+
+
 # ---------------------------------------------------------------------------
 # Integration with ACPClient
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #52. Closes #58.

Adds support for the kiro-cli **v3 agent engine** and, on top of it, native
document forwarding. `KIRO_ACP_ENGINE=v2` remains the default and its behaviour
is unchanged.

## Why v3 needed work

`kiro-cli acp --agent-engine v3` does not run the agent itself: it spawns the
Kiro Agent Server (KAS) with a **hardcoded** `--auth=acp-callback`, so the server
asks its ACP client for an access token. Verified against a live process:

```
node --experimental-wasm-modules …/@kiro/agent/dist/server/acp-server.js \
     --transport=stdio --auth=acp-callback
```

Declining that callback let `initialize` and `session/new` succeed but failed
every `session/prompt` with `-32000 Auth refresh callback failed`.

## The auth bridge (`kiro/kiro_auth.py`)

The callback is answered by shelling out to `kiro-cli chat _ get-kas-token`, so
kiro-cli keeps the OIDC refresh token and performs the refresh itself. The
gateway:

* never reads or transmits the **refresh token**, and performs no OIDC flow;
* never caches, persists or logs a token (KAS caches internally — a probe showed
  one callback per subprocess);
* forwards only the covenant keys (`accessToken`, `expiresAt`, `profileArn`,
  `authMethod`, `provider`);
* sends it nowhere but kiro-cli's own agent server.

This is the same mechanism used by [`kirodotdev/KiroCrew`](https://github.com/kirodotdev/KiroCrew)
in `src/kiro_crew/acp/kas_auth.py`. On v1/v2 the resolver is not even
constructed, so the default engine stays completely credential-free.
`ACP_AUTH_BRIDGE=false` makes v3 fail closed with a native `401` instead of
relaying a credential.

COMPLIANCE.md documents this as an explicit, scoped exception, including the
three rejected alternatives (reading kiro-cli's credential store, refreshing in
the gateway, spawning KAS directly).

## Other v3 protocol differences (each gated on the engine)

* **JSON-RPC responses now carry exactly one of `result`/`error`.** The previous
  `result: null` alongside `error` made v3 report an opaque
  `-32603 Internal error` ("Cannot read properties of null") instead of the
  message sent. v2 tolerated it.
* **Model selection uses `session/set_config_option`** — v3 implements no
  `session/set_model`.
* **The catalogue is read from `configOptions`** (v3 returns no `models` block)
  and refreshed from `config_option_update`, so `GET /v1/models` stays live.
* **Tool output** is extracted from v3's flat `rawOutput.output` as well as v2's
  `{"items": [{"Text": …}]}`.
* Every other v3 client callback (`_kiro/fs/*`, hooks, checkpoints,
  `openExternalUrl`) is still **declined**, keeping the least-privilege posture.

## Bug fixed on both engines: unserved models

An unserved model id was put on the wire, which hangs the turn ~4 minutes and
then fails — `504` on v2 and a misleading "Access denied" on v3 — rather than
falling back as `MODEL_VALIDATION=warn` already reported. This affected harnesses
configured with `claude-sonnet-4.6` (what the README recommends) on accounts that
are not served that model. `_is_served` now withholds an id absent from the live
catalogue; `MODEL_VALIDATION=off` still forces it.

An unusable kiro-cli login now classifies as `401 authentication_error` in both
shims and both modes instead of a generic `502`.

## Documents as embedded context (#58)

Representation follows the negotiated `promptCapabilities.embeddedContext`, never
the engine string:

* **true (v3)** → an ACP `resource` block (`{"uri","mimeType","text"|"blob"}`) so
  the agent parses the original bytes — a probe confirmed the model reads markers
  from both a `text` resource and a base64 `blob` PDF.
* **false (v1/v2)** → unchanged text reduction (`pypdf` for PDFs, explicit
  placeholder otherwise). A probe showed v2 accepts a `resource` block **without
  error but silently ignores it**, so this is capability-gated rather than
  try-and-fall-back.

## Testing

`uv run pytest -q` → **1013 passed, 1 skipped** (999 before the #58 commit, 913
on `main`). `kiro/kiro_auth.py` and `kiro/error_mapping.py` are at 100% coverage.

Everything below was also exercised **live** against kiro-cli 2.18.0 / KAS 0.38.7
on **both v2 and v3**, streaming and non-streaming:

* OpenAI chat + Responses, Anthropic messages, native `/acp/chat[/stream]`,
  `/v1/models` + retrieve, `count_tokens`, key enforcement, multi-turn with
  system roles — 14/14 per engine.
* Reasoning (`reasoning_content`, Anthropic `thinking`, Responses reasoning
  items), images, documents, usage + `kiro_metadata`, `stop` enforcement,
  embeddings `501`, stateful-Responses `400`, workspace/MCP headers — 25/25 per
  engine.
* Harness MCP (#75): workspace `.mcp.json` discovery, `X-Kiro-MCP-Servers`
  header, `mcp_servers` body field, malformed-config tolerance — 6/6 per engine,
  using a purpose-built stdio MCP server so tool **execution** is proven, not
  just registration.
* `ACP_SURFACE_TOOL_CALLS=true` and `ACP_TRUST_TOOLS=false` profiles.
* Claude Code- and OpenCode-shaped payloads, a real built-in tool run, and the
  declined-bridge auth failure (native `401` on both shims; gateway logs scanned
  for credential leakage — zero hits).

v1/v2 wire bytes are unchanged: the serialised `_build_prompt_blocks` output for
8 document/image/text cases is **byte-identical to `main`**, verified by diffing
across both checkouts.

## Config added

| Variable | Default | Purpose |
|---|---|---|
| `ACP_AUTH_BRIDGE` | `true` | v3 only: relay a short-lived kiro-cli access token to the agent server. Inert on v1/v2. `false` = fail closed with `401`. |

Docs updated: README, AGENTS.md (a v3 section recording each verified wire
difference), COMPLIANCE.md (the scoped exception), `.env.example`.

> Note: issue #52 states v3 "blocked at `session/new`". On kiro-cli 2.18.0
> `session/new` succeeds and only `session/prompt` fails.
